### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/examples/pixelAccess.cc
+++ b/examples/pixelAccess.cc
@@ -1,5 +1,5 @@
 #include "Eigen/Core"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "boost/timer.hpp"
 
 #include "lsst/afw/geom.h"
@@ -36,8 +36,8 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
     
     if (cswitch == 3) {
         /* a list of images - in diffim each one of these is associated with a basis function */
-        std::vector<boost::shared_ptr<Eigen::VectorXd> > imageList(nParameters);
-        typename std::vector<boost::shared_ptr<Eigen::VectorXd> >::iterator eiter = imageList.begin();
+        std::vector<std::shared_ptr<Eigen::VectorXd> > imageList(nParameters);
+        typename std::vector<std::shared_ptr<Eigen::VectorXd> >::iterator eiter = imageList.begin();
         afwImage::Image<ImageT> cimage(varianceEstimate.getDimensions());
         for (int i = 1; eiter != imageList.end(); ++eiter, ++i) {
             cimage = i; /* give it a value */
@@ -45,7 +45,7 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
                                                                             endRow-startRow, 
                                                                             endCol-startCol);
             cMat.resize(cMat.rows()*cMat.cols(), 1);
-            boost::shared_ptr<Eigen::VectorXd> vMat (new Eigen::VectorXd(cMat.col(0)));
+            std::shared_ptr<Eigen::VectorXd> vMat (new Eigen::VectorXd(cMat.col(0)));
             *eiter = vMat;
         } 
         
@@ -58,8 +58,8 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
         Eigen::VectorXd eigeniVarianceV      = eigeniVarianceM.col(0);
         
         Eigen::MatrixXd cMat(eigeniVarianceV.size(), nParameters);
-        typename std::vector<boost::shared_ptr<Eigen::VectorXd> >::iterator eiterj = imageList.begin();
-        typename std::vector<boost::shared_ptr<Eigen::VectorXd> >::iterator eiterE = imageList.end();
+        typename std::vector<std::shared_ptr<Eigen::VectorXd> >::iterator eiterj = imageList.begin();
+        typename std::vector<std::shared_ptr<Eigen::VectorXd> >::iterator eiterE = imageList.end();
         for (unsigned int kidxj = 0; eiterj != eiterE; eiterj++, kidxj++) {
             cMat.block(0, kidxj, eigeniVarianceV.size(), 1) = 
                 Eigen::MatrixXd(**eiterj).block(0, 0, eigeniVarianceV.size(), 1);
@@ -75,8 +75,8 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
     }
     else if (cswitch == 2) {
         /* a list of images - in diffim each one of these is associated with a basis function */
-        std::vector<boost::shared_ptr<Eigen::VectorXd> > imageList(nParameters);
-        typename std::vector<boost::shared_ptr<Eigen::VectorXd> >::iterator eiter = imageList.begin();
+        std::vector<std::shared_ptr<Eigen::VectorXd> > imageList(nParameters);
+        typename std::vector<std::shared_ptr<Eigen::VectorXd> >::iterator eiter = imageList.begin();
         afwImage::Image<ImageT> cimage(varianceEstimate.getDimensions());
         for (int i = 1; eiter != imageList.end(); ++eiter, ++i) {
             cimage = i; /* give it a value */
@@ -85,7 +85,7 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
                                                                             endRow-startRow, 
                                                                             endCol-startCol);
             cMat.resize(cMat.rows()*cMat.cols(), 1);
-            boost::shared_ptr<Eigen::VectorXd> vMat (new Eigen::VectorXd(cMat.col(0)));
+            std::shared_ptr<Eigen::VectorXd> vMat (new Eigen::VectorXd(cMat.col(0)));
             *eiter = vMat;
         } 
         
@@ -97,12 +97,12 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
         eigeniVarianceM.resize(eigeniVarianceM.rows()*eigeniVarianceM.cols(), 1);
         Eigen::VectorXd eigeniVarianceV      = eigeniVarianceM.col(0);
         
-        typename std::vector<boost::shared_ptr<Eigen::VectorXd> >::iterator eiteri = imageList.begin();
-        typename std::vector<boost::shared_ptr<Eigen::VectorXd> >::iterator eiterE = imageList.end();
+        typename std::vector<std::shared_ptr<Eigen::VectorXd> >::iterator eiteri = imageList.begin();
+        typename std::vector<std::shared_ptr<Eigen::VectorXd> >::iterator eiterE = imageList.end();
         for (unsigned int kidxi = 0; eiteri != eiterE; eiteri++, kidxi++) {
             Eigen::VectorXd eiteriDotiVariance = ((*eiteri)->array() * eigeniVarianceV.array()).matrix();
             
-            typename std::vector<boost::shared_ptr<Eigen::VectorXd> >::iterator eiterj = eiteri;
+            typename std::vector<std::shared_ptr<Eigen::VectorXd> >::iterator eiterj = eiteri;
             for (unsigned int kidxj = kidxi; eiterj != eiterE; eiterj++, kidxj++) {
                 mMat(kidxi, kidxj) = (eiteriDotiVariance.array() * (**eiterj).array()).sum();
                 mMat(kidxj, kidxi) = mMat(kidxi, kidxj);
@@ -113,8 +113,8 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
     else {
         
         /* a list of images - in diffim each one of these is associated with a basis function */
-        std::vector<boost::shared_ptr<afwImage::Image<ImageT> > > imageList(nParameters);
-        typename std::vector<boost::shared_ptr<afwImage::Image<ImageT> > >::iterator citer=imageList.begin();
+        std::vector<std::shared_ptr<afwImage::Image<ImageT> > > imageList(nParameters);
+        typename std::vector<std::shared_ptr<afwImage::Image<ImageT> > >::iterator citer=imageList.begin();
         for (int i = 1; citer != imageList.end(); ++citer, ++i) {
             *citer = typename afwImage::Image<ImageT>::Ptr(
                 new afwImage::Image<ImageT>(varianceEstimate.getDimensions())

--- a/include/lsst/ip/diffim/AssessSpatialKernelVisitor.h
+++ b/include/lsst/ip/diffim/AssessSpatialKernelVisitor.h
@@ -26,7 +26,7 @@ namespace detail {
     class AssessSpatialKernelVisitor : public lsst::afw::math::CandidateVisitor {
         typedef lsst::afw::image::MaskedImage<PixelT> MaskedImageT;
     public:
-        typedef boost::shared_ptr<AssessSpatialKernelVisitor<PixelT> > Ptr;
+        typedef std::shared_ptr<AssessSpatialKernelVisitor<PixelT> > Ptr;
 
         AssessSpatialKernelVisitor(
             lsst::afw::math::LinearCombinationKernel::Ptr spatialKernel,   ///< Spatially varying kernel 
@@ -56,7 +56,7 @@ namespace detail {
     };
 
     template<typename PixelT>
-    boost::shared_ptr<AssessSpatialKernelVisitor<PixelT> >
+    std::shared_ptr<AssessSpatialKernelVisitor<PixelT> >
     makeAssessSpatialKernelVisitor(
         lsst::afw::math::LinearCombinationKernel::Ptr spatialKernel,   
         lsst::afw::math::Kernel::SpatialFunctionPtr spatialBackground, 

--- a/include/lsst/ip/diffim/BasisLists.h
+++ b/include/lsst/ip/diffim/BasisLists.h
@@ -12,7 +12,7 @@
 #ifndef LSST_IP_DIFFIM_BASISSETS_H
 #define LSST_IP_DIFFIM_BASISSETS_H
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "Eigen/Core"
 
@@ -48,7 +48,7 @@ namespace diffim {
      * @note Calls either makeForwardDifferenceMatrix or
      * makeCentralDifferenceMatrix based on the policy file.
      */    
-    boost::shared_ptr<Eigen::MatrixXd> makeRegularizationMatrix(
+    std::shared_ptr<Eigen::MatrixXd> makeRegularizationMatrix(
         lsst::pex::policy::Policy policy
         );
 
@@ -63,7 +63,7 @@ namespace diffim {
      *
      * @ingroup ip_diffim
      */    
-    boost::shared_ptr<Eigen::MatrixXd> makeForwardDifferenceMatrix(
+    std::shared_ptr<Eigen::MatrixXd> makeForwardDifferenceMatrix(
         int width,
         int height,
         std::vector<int> const& orders,
@@ -82,7 +82,7 @@ namespace diffim {
      *
      * @ingroup ip_diffim
      */    
-    boost::shared_ptr<Eigen::MatrixXd> makeCentralDifferenceMatrix(
+    std::shared_ptr<Eigen::MatrixXd> makeCentralDifferenceMatrix(
         int width,
         int height,
         int stencil,

--- a/include/lsst/ip/diffim/BuildSingleKernelVisitor.h
+++ b/include/lsst/ip/diffim/BuildSingleKernelVisitor.h
@@ -12,7 +12,7 @@
 #ifndef LSST_IP_DIFFIM_BUILDSINGLEKERNELVISITOR_H
 #define LSST_IP_DIFFIM_BUILDSINGLEKERNELVISITOR_H
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "lsst/afw/image.h"
 #include "lsst/afw/math.h"
@@ -30,7 +30,7 @@ namespace detail {
     class BuildSingleKernelVisitor : public lsst::afw::math::CandidateVisitor {
         typedef lsst::afw::image::MaskedImage<PixelT> MaskedImageT;
     public:
-        typedef boost::shared_ptr<BuildSingleKernelVisitor<PixelT> > Ptr;
+        typedef std::shared_ptr<BuildSingleKernelVisitor<PixelT> > Ptr;
 
         BuildSingleKernelVisitor(
             lsst::afw::math::KernelList const& basisList,
@@ -39,7 +39,7 @@ namespace detail {
         BuildSingleKernelVisitor(
             lsst::afw::math::KernelList const& basisList,
             lsst::pex::policy::Policy const& policy, 
-            boost::shared_ptr<Eigen::MatrixXd> hMat  
+            std::shared_ptr<Eigen::MatrixXd> hMat  
             );
         virtual ~BuildSingleKernelVisitor() {};
         
@@ -61,7 +61,7 @@ namespace detail {
     private:
         lsst::afw::math::KernelList const _basisList; ///< Basis set
         lsst::pex::policy::Policy _policy;            ///< Policy controlling behavior
-        boost::shared_ptr<Eigen::MatrixXd> _hMat;     ///< Regularization matrix
+        std::shared_ptr<Eigen::MatrixXd> _hMat;     ///< Regularization matrix
         ImageStatistics<PixelT> _imstats;     ///< To calculate statistics of difference image
         bool _skipBuilt;                      ///< Skip over built candidates during processCandidate()
         int _nRejected;                       ///< Number of candidates rejected during processCandidate()
@@ -73,7 +73,7 @@ namespace detail {
     };
     
     template<typename PixelT>
-    boost::shared_ptr<BuildSingleKernelVisitor<PixelT> >
+    std::shared_ptr<BuildSingleKernelVisitor<PixelT> >
     makeBuildSingleKernelVisitor(
         lsst::afw::math::KernelList const& basisList,
         lsst::pex::policy::Policy const& policy
@@ -85,11 +85,11 @@ namespace detail {
     }
 
     template<typename PixelT>
-    boost::shared_ptr<BuildSingleKernelVisitor<PixelT> >
+    std::shared_ptr<BuildSingleKernelVisitor<PixelT> >
     makeBuildSingleKernelVisitor(
         lsst::afw::math::KernelList const& basisList,
         lsst::pex::policy::Policy const& policy,
-        boost::shared_ptr<Eigen::MatrixXd> hMat  
+        std::shared_ptr<Eigen::MatrixXd> hMat  
         ) {
 
         return typename BuildSingleKernelVisitor<PixelT>::Ptr(

--- a/include/lsst/ip/diffim/BuildSpatialKernelVisitor.h
+++ b/include/lsst/ip/diffim/BuildSpatialKernelVisitor.h
@@ -26,7 +26,7 @@ namespace detail {
     template<typename PixelT>
     class BuildSpatialKernelVisitor : public lsst::afw::math::CandidateVisitor {
     public:
-        typedef boost::shared_ptr<BuildSpatialKernelVisitor<PixelT> > Ptr;
+        typedef std::shared_ptr<BuildSpatialKernelVisitor<PixelT> > Ptr;
 
         BuildSpatialKernelVisitor(
             lsst::afw::math::KernelList const& basisList,  ///< Basis functions
@@ -40,18 +40,18 @@ namespace detail {
 
         void solveLinearEquation();
   
-        inline boost::shared_ptr<SpatialKernelSolution> getKernelSolution() {return _kernelSolution;}
+        inline std::shared_ptr<SpatialKernelSolution> getKernelSolution() {return _kernelSolution;}
 
         std::pair<lsst::afw::math::LinearCombinationKernel::Ptr, 
                   lsst::afw::math::Kernel::SpatialFunctionPtr> getSolutionPair();
 
     private:
-        boost::shared_ptr<SpatialKernelSolution> _kernelSolution;
+        std::shared_ptr<SpatialKernelSolution> _kernelSolution;
         int _nCandidates;                  ///< Number of candidates visited
     };
 
     template<typename PixelT>
-    boost::shared_ptr<BuildSpatialKernelVisitor<PixelT> >
+    std::shared_ptr<BuildSpatialKernelVisitor<PixelT> >
     makeBuildSpatialKernelVisitor(
         lsst::afw::math::KernelList const& basisList,
         lsst::afw::geom::Box2I const& regionBBox,

--- a/include/lsst/ip/diffim/ImageStatistics.h
+++ b/include/lsst/ip/diffim/ImageStatistics.h
@@ -36,7 +36,7 @@
 #define LSST_IP_DIFFIM_IMAGESTATISTICS_H
 
 #include <limits>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "lsst/afw/image.h"
 #include "lsst/pex/policy/Policy.h"
 #include "lsst/pex/logging/Trace.h"
@@ -57,7 +57,7 @@ namespace diffim {
     template <typename PixelT>
     class ImageStatistics {
     public:
-        typedef boost::shared_ptr<ImageStatistics> Ptr;
+        typedef std::shared_ptr<ImageStatistics> Ptr;
         typedef typename lsst::afw::image::MaskedImage<PixelT>::x_iterator x_iterator;
 
         ImageStatistics(lsst::pex::policy::Policy const& policy) : 

--- a/include/lsst/ip/diffim/KernelCandidate.h
+++ b/include/lsst/ip/diffim/KernelCandidate.h
@@ -12,7 +12,7 @@
 #ifndef LSST_IP_DIFFIM_KERNELCANDIDATE_H
 #define LSST_IP_DIFFIM_KERNELCANDIDATE_H
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 
 #include "lsst/afw/math.h"
@@ -45,10 +45,10 @@ namespace diffim {
         using afw::math::SpatialCellImageCandidate<afw::math::Kernel::Pixel>::_image;
 
     public:
-        typedef boost::shared_ptr<KernelCandidate> Ptr;
-        typedef boost::shared_ptr<afw::image::MaskedImage<PixelT> > MaskedImagePtr;
-        typedef boost::shared_ptr<afw::image::Image<afw::image::VariancePixel> > VariancePtr;
-        typedef boost::shared_ptr<afw::table::SourceRecord> SourcePtr;
+        typedef std::shared_ptr<KernelCandidate> Ptr;
+        typedef std::shared_ptr<afw::image::MaskedImage<PixelT> > MaskedImagePtr;
+        typedef std::shared_ptr<afw::image::Image<afw::image::VariancePixel> > VariancePtr;
+        typedef std::shared_ptr<afw::table::SourceRecord> SourcePtr;
 
         enum CandidateSwitch {
             ORIG    = 0,
@@ -112,7 +112,7 @@ namespace diffim {
         double getKsum(CandidateSwitch cand) const;
         PTR(ImageT) getKernelImage(CandidateSwitch cand) const;
         CONST_PTR(ImageT) getImage() const; // For SpatialCellImageCandidate
-        boost::shared_ptr<StaticKernelSolution<PixelT> > getKernelSolution(CandidateSwitch cand) const;
+        std::shared_ptr<StaticKernelSolution<PixelT> > getKernelSolution(CandidateSwitch cand) const;
 
         /**
          * @brief Calculate associated difference image using internal solutions
@@ -183,7 +183,7 @@ namespace diffim {
             );
         void build(
             afw::math::KernelList const& basisList,
-            boost::shared_ptr<Eigen::MatrixXd> hMat
+            std::shared_ptr<Eigen::MatrixXd> hMat
             );
 
     private:
@@ -198,13 +198,13 @@ namespace diffim {
         bool _fitForBackground;
 
         /* best single raw kernel */
-        boost::shared_ptr<StaticKernelSolution<PixelT> > _kernelSolutionOrig; ///< Original basis solution
+        std::shared_ptr<StaticKernelSolution<PixelT> > _kernelSolutionOrig; ///< Original basis solution
 
         /* with Pca basis */
-        boost::shared_ptr<StaticKernelSolution<PixelT> > _kernelSolutionPca;  ///< Most recent  solution
+        std::shared_ptr<StaticKernelSolution<PixelT> > _kernelSolutionPca;  ///< Most recent  solution
 
         void _buildKernelSolution(afw::math::KernelList const& basisList,
-                                  boost::shared_ptr<Eigen::MatrixXd> hMat);
+                                  std::shared_ptr<Eigen::MatrixXd> hMat);
     };
 
 
@@ -220,11 +220,11 @@ namespace diffim {
      * @ingroup ip_diffim
      */
     template <typename PixelT>
-    boost::shared_ptr<KernelCandidate<PixelT> >
+    std::shared_ptr<KernelCandidate<PixelT> >
     makeKernelCandidate(float const xCenter,
                         float const yCenter,
-                        boost::shared_ptr<afw::image::MaskedImage<PixelT> > const& templateMaskedImage,
-                        boost::shared_ptr<afw::image::MaskedImage<PixelT> > const& scienceMaskedImage,
+                        std::shared_ptr<afw::image::MaskedImage<PixelT> > const& templateMaskedImage,
+                        std::shared_ptr<afw::image::MaskedImage<PixelT> > const& scienceMaskedImage,
                         pex::policy::Policy const& policy){
 
         return typename KernelCandidate<PixelT>::Ptr(new KernelCandidate<PixelT>(xCenter, yCenter,
@@ -245,10 +245,10 @@ namespace diffim {
      * @ingroup ip_diffim
      */
     template <typename PixelT>
-    boost::shared_ptr<KernelCandidate<PixelT> >
-    makeKernelCandidate(boost::shared_ptr<afw::table::SourceRecord> const & source,
-                        boost::shared_ptr<afw::image::MaskedImage<PixelT> > const& templateMaskedImage,
-                        boost::shared_ptr<afw::image::MaskedImage<PixelT> > const& scienceMaskedImage,
+    std::shared_ptr<KernelCandidate<PixelT> >
+    makeKernelCandidate(std::shared_ptr<afw::table::SourceRecord> const & source,
+                        std::shared_ptr<afw::image::MaskedImage<PixelT> > const& templateMaskedImage,
+                        std::shared_ptr<afw::image::MaskedImage<PixelT> > const& scienceMaskedImage,
                         pex::policy::Policy const& policy){
 
         return typename KernelCandidate<PixelT>::Ptr(new KernelCandidate<PixelT>(source,

--- a/include/lsst/ip/diffim/KernelCandidateDetection.h
+++ b/include/lsst/ip/diffim/KernelCandidateDetection.h
@@ -34,8 +34,8 @@ namespace diffim {
     template <typename PixelT>
     class KernelCandidateDetection {
     public:
-        typedef boost::shared_ptr<KernelCandidateDetection> Ptr;
-        typedef boost::shared_ptr<lsst::afw::image::MaskedImage<PixelT> > MaskedImagePtr;
+        typedef std::shared_ptr<KernelCandidateDetection> Ptr;
+        typedef std::shared_ptr<lsst::afw::image::MaskedImage<PixelT> > MaskedImagePtr;
 
         KernelCandidateDetection(lsst::pex::policy::Policy const& policy);
 

--- a/include/lsst/ip/diffim/KernelPca.h
+++ b/include/lsst/ip/diffim/KernelPca.h
@@ -24,7 +24,7 @@ namespace detail {
     class KernelPca : public lsst::afw::image::ImagePca<ImageT> {
         typedef typename lsst::afw::image::ImagePca<ImageT> Super; ///< Base class
     public:
-        typedef typename boost::shared_ptr<KernelPca<ImageT> > Ptr;
+        typedef typename std::shared_ptr<KernelPca<ImageT> > Ptr;
         using lsst::afw::image::ImagePca<ImageT>::getEigenImages;
         using lsst::afw::image::ImagePca<ImageT>::getEigenValues;
         using lsst::afw::image::ImagePca<ImageT>::addImage;
@@ -40,9 +40,9 @@ namespace detail {
     class KernelPcaVisitor : public lsst::afw::math::CandidateVisitor {
     public:
         typedef lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel> ImageT;
-        typedef boost::shared_ptr<KernelPcaVisitor<PixelT> > Ptr;
+        typedef std::shared_ptr<KernelPcaVisitor<PixelT> > Ptr;
         
-        KernelPcaVisitor(boost::shared_ptr<KernelPca<ImageT> > imagePca);
+        KernelPcaVisitor(std::shared_ptr<KernelPca<ImageT> > imagePca);
         virtual ~KernelPcaVisitor() {};
         
         lsst::afw::math::KernelList getEigenKernels();
@@ -50,13 +50,13 @@ namespace detail {
         void subtractMean();
         PTR(ImageT) returnMean() {return _mean;}
     private:
-        boost::shared_ptr<KernelPca<ImageT> > _imagePca;  ///< Structure to fill with images
+        std::shared_ptr<KernelPca<ImageT> > _imagePca;  ///< Structure to fill with images
         PTR(ImageT) _mean;                                ///< Mean image calculated before Pca
     };
 
     template<typename PixelT>
-    boost::shared_ptr<KernelPcaVisitor<PixelT> >
-    makeKernelPcaVisitor(boost::shared_ptr<KernelPca<typename KernelPcaVisitor<PixelT>::ImageT> > imagePca) {
+    std::shared_ptr<KernelPcaVisitor<PixelT> >
+    makeKernelPcaVisitor(std::shared_ptr<KernelPca<typename KernelPcaVisitor<PixelT>::ImageT> > imagePca) {
         return typename KernelPcaVisitor<PixelT>::Ptr(new KernelPcaVisitor<PixelT>(imagePca));
     };
 

--- a/include/lsst/ip/diffim/KernelSolution.h
+++ b/include/lsst/ip/diffim/KernelSolution.h
@@ -12,7 +12,7 @@
 #ifndef LSST_IP_DIFFIM_KERNELSOLUTION_H
 #define LSST_IP_DIFFIM_KERNELSOLUTION_H
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 
 #include "lsst/afw/math.h"
@@ -29,7 +29,7 @@ namespace diffim {
 
     class KernelSolution {
     public:
-        typedef boost::shared_ptr<KernelSolution> Ptr;
+        typedef std::shared_ptr<KernelSolution> Ptr;
         typedef lsst::afw::math::Kernel::Pixel PixelT;
         typedef lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel> ImageT;
 
@@ -46,8 +46,8 @@ namespace diffim {
             SVD        = 1
         };
 
-        explicit KernelSolution(boost::shared_ptr<Eigen::MatrixXd> mMat,
-                                boost::shared_ptr<Eigen::VectorXd> bVec,
+        explicit KernelSolution(std::shared_ptr<Eigen::MatrixXd> mMat,
+                                std::shared_ptr<Eigen::VectorXd> bVec,
                                 bool fitForBackground);
         explicit KernelSolution(bool fitForBackground);
         explicit KernelSolution();
@@ -60,8 +60,8 @@ namespace diffim {
         virtual double getConditionNumber(ConditionNumberType conditionType);
         virtual double getConditionNumber(Eigen::MatrixXd mMat, ConditionNumberType conditionType);
 
-        inline boost::shared_ptr<Eigen::MatrixXd> getM() {return _mMat;}
-        inline boost::shared_ptr<Eigen::VectorXd> getB() {return _bVec;}
+        inline std::shared_ptr<Eigen::MatrixXd> getM() {return _mMat;}
+        inline std::shared_ptr<Eigen::VectorXd> getB() {return _bVec;}
         void printM() {std::cout << *_mMat << std::endl;}
         void printB() {std::cout << *_bVec << std::endl;}
         void printA() {std::cout << *_aVec << std::endl;}
@@ -69,9 +69,9 @@ namespace diffim {
 
     protected:
         int _id;                                                ///< Unique ID for object
-        boost::shared_ptr<Eigen::MatrixXd> _mMat;               ///< Derived least squares M matrix
-        boost::shared_ptr<Eigen::VectorXd> _bVec;               ///< Derived least squares B vector
-        boost::shared_ptr<Eigen::VectorXd> _aVec;               ///< Derived least squares solution matrix
+        std::shared_ptr<Eigen::MatrixXd> _mMat;               ///< Derived least squares M matrix
+        std::shared_ptr<Eigen::VectorXd> _bVec;               ///< Derived least squares B vector
+        std::shared_ptr<Eigen::VectorXd> _aVec;               ///< Derived least squares solution matrix
         KernelSolvedBy _solvedBy;                               ///< Type of algorithm used to make solution
         bool _fitForBackground;                                 ///< Background terms included in fit
         static int _SolutionId;                                 ///< Unique identifier for solution
@@ -81,7 +81,7 @@ namespace diffim {
     template <typename InputT>
     class StaticKernelSolution : public KernelSolution {
     public:
-        typedef boost::shared_ptr<StaticKernelSolution<InputT> > Ptr;
+        typedef std::shared_ptr<StaticKernelSolution<InputT> > Ptr;
 
         StaticKernelSolution(lsst::afw::math::KernelList const& basisList,
                              bool fitForBackground);
@@ -98,12 +98,12 @@ namespace diffim {
         virtual lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>::Ptr makeKernelImage();
         virtual double getBackground();
         virtual double getKsum();
-        virtual std::pair<boost::shared_ptr<lsst::afw::math::Kernel>, double> getSolutionPair();
+        virtual std::pair<std::shared_ptr<lsst::afw::math::Kernel>, double> getSolutionPair();
 
     protected:
-        boost::shared_ptr<Eigen::MatrixXd> _cMat;               ///< K_i x R
-        boost::shared_ptr<Eigen::VectorXd> _iVec;               ///< Vectorized I
-        boost::shared_ptr<Eigen::VectorXd> _ivVec;              ///< Inverse variance
+        std::shared_ptr<Eigen::MatrixXd> _cMat;               ///< K_i x R
+        std::shared_ptr<Eigen::VectorXd> _iVec;               ///< Vectorized I
+        std::shared_ptr<Eigen::VectorXd> _ivVec;              ///< Inverse variance
 
         lsst::afw::math::Kernel::Ptr _kernel;                   ///< Derived single-object convolution kernel
         double _background;                                     ///< Derived differential background estimate
@@ -117,7 +117,7 @@ namespace diffim {
     template <typename InputT>
     class MaskedKernelSolution : public StaticKernelSolution<InputT> {
     public:
-        typedef boost::shared_ptr<MaskedKernelSolution<InputT> > Ptr;
+        typedef std::shared_ptr<MaskedKernelSolution<InputT> > Ptr;
 
         MaskedKernelSolution(lsst::afw::math::KernelList const& basisList,
                              bool fitForBackground);
@@ -146,11 +146,11 @@ namespace diffim {
     template <typename InputT>
     class RegularizedKernelSolution : public StaticKernelSolution<InputT> {
     public:
-        typedef boost::shared_ptr<RegularizedKernelSolution<InputT> > Ptr;
+        typedef std::shared_ptr<RegularizedKernelSolution<InputT> > Ptr;
 
         RegularizedKernelSolution(lsst::afw::math::KernelList const& basisList,
                                   bool fitForBackground,
-                                  boost::shared_ptr<Eigen::MatrixXd> hMat,
+                                  std::shared_ptr<Eigen::MatrixXd> hMat,
                                   lsst::pex::policy::Policy policy
                                   );
         virtual ~RegularizedKernelSolution() {};
@@ -159,10 +159,10 @@ namespace diffim {
         double estimateRisk(double maxCond);
 
         /* Include additive term (_lambda * _hMat) in M matrix? */
-        boost::shared_ptr<Eigen::MatrixXd> getM(bool includeHmat = true);
+        std::shared_ptr<Eigen::MatrixXd> getM(bool includeHmat = true);
 
     private:
-        boost::shared_ptr<Eigen::MatrixXd> _hMat;               ///< Regularization weights
+        std::shared_ptr<Eigen::MatrixXd> _hMat;               ///< Regularization weights
         double _lambda;                                         ///< Overall regularization strength
         lsst::pex::policy::Policy _policy;
 
@@ -172,7 +172,7 @@ namespace diffim {
 
     class SpatialKernelSolution : public KernelSolution {
     public:
-        typedef boost::shared_ptr<SpatialKernelSolution> Ptr;
+        typedef std::shared_ptr<SpatialKernelSolution> Ptr;
 
         /* Creates a polynomial SpatialFunction */
         SpatialKernelSolution(lsst::afw::math::KernelList const& basisList,
@@ -184,8 +184,8 @@ namespace diffim {
         virtual ~SpatialKernelSolution() {};
         
         void addConstraint(float xCenter, float yCenter,
-                           boost::shared_ptr<Eigen::MatrixXd> qMat,
-                           boost::shared_ptr<Eigen::VectorXd> wVec);
+                           std::shared_ptr<Eigen::MatrixXd> qMat,
+                           std::shared_ptr<Eigen::VectorXd> wVec);
 
         void solve();
         lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>::Ptr makeKernelImage(lsst::afw::geom::Point2D const& pos);

--- a/include/lsst/ip/diffim/KernelSumVisitor.h
+++ b/include/lsst/ip/diffim/KernelSumVisitor.h
@@ -12,7 +12,7 @@
 #ifndef LSST_IP_DIFFIM_KERNELSUMVISITOR_H
 #define LSST_IP_DIFFIM_KERNELSUMVISITOR_H
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "lsst/afw/math.h"
 #include "lsst/afw/image.h"
 #include "lsst/pex/policy/Policy.h"
@@ -25,7 +25,7 @@ namespace detail {
     template<typename PixelT>
     class KernelSumVisitor : public lsst::afw::math::CandidateVisitor {
     public:
-        typedef boost::shared_ptr<KernelSumVisitor<PixelT> > Ptr;
+        typedef std::shared_ptr<KernelSumVisitor<PixelT> > Ptr;
 
         enum Mode {AGGREGATE = 0, REJECT = 1};
         
@@ -55,7 +55,7 @@ namespace detail {
     };    
     
     template<typename PixelT>
-    boost::shared_ptr<KernelSumVisitor<PixelT> >
+    std::shared_ptr<KernelSumVisitor<PixelT> >
     makeKernelSumVisitor(lsst::pex::policy::Policy const& policy) {
         return typename KernelSumVisitor<PixelT>::Ptr(new KernelSumVisitor<PixelT>(policy));
     }

--- a/python/lsst/ip/diffim/detail.i
+++ b/python/lsst/ip/diffim/detail.i
@@ -25,7 +25,7 @@
 
 %{
 #include "lsst/ip/diffim/KernelPca.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 %}
 
 %define %KernelPcaVisitorPtr(TYPE)
@@ -46,7 +46,7 @@
     %inline %{
         lsst::ip::diffim::detail::KernelPca<lsst::afw::image::Image<TYPE> >::Ptr
             cast_KernelPca##NAME(lsst::afw::image::ImagePca<lsst::afw::image::Image<TYPE> >::Ptr imagePca) {
-            return boost::dynamic_pointer_cast<lsst::ip::diffim::detail::KernelPca<lsst::afw::image::Image<TYPE> > >(imagePca);
+            return std::dynamic_pointer_cast<lsst::ip::diffim::detail::KernelPca<lsst::afw::image::Image<TYPE> > >(imagePca);
         }
     %}
 %enddef

--- a/python/lsst/ip/diffim/detail/diffimDetailLib.i
+++ b/python/lsst/ip/diffim/detail/diffimDetailLib.i
@@ -10,7 +10,7 @@ Python bindings for lsst::ip::diffim::detail code
 
 // Everything we will need in the _wrap.cc file
 %{
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "lsst/pex/exceptions.h"
 #include "lsst/pex/logging.h"

--- a/python/lsst/ip/diffim/diffimLib.i
+++ b/python/lsst/ip/diffim/diffimLib.i
@@ -56,7 +56,7 @@ namespace boost {
 %apply double& OUTPUT { double& };
 
 %{
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 
 #include "lsst/pex/exceptions.h"
@@ -84,8 +84,8 @@ namespace boost {
 %}
 %include "ndarray.i"
 
-%template(PtrEigenMatrixXd) boost::shared_ptr<Eigen::MatrixXd>;
-%template(PtrEigenVectorXd) boost::shared_ptr<Eigen::VectorXd>;
+%template(PtrEigenMatrixXd) std::shared_ptr<Eigen::MatrixXd>;
+%template(PtrEigenVectorXd) std::shared_ptr<Eigen::VectorXd>;
 %declareNumPyConverters(Eigen::MatrixXd);
 %declareNumPyConverters(Eigen::VectorXd);
 %shared_ptr(Eigen::MatrixXd);
@@ -220,7 +220,7 @@ lsst::afw::image::Image<PIXTYPE>
 %inline %{
     lsst::ip::diffim::KernelCandidate<TYPE>::Ptr
         cast_KernelCandidate##NAME(lsst::afw::math::SpatialCellCandidate::Ptr candidate) {
-        return boost::dynamic_pointer_cast<lsst::ip::diffim::KernelCandidate<TYPE> >(candidate);
+        return std::dynamic_pointer_cast<lsst::ip::diffim::KernelCandidate<TYPE> >(candidate);
     }
 %}
 %enddef

--- a/src/AssessSpatialKernelVisitor.cc
+++ b/src/AssessSpatialKernelVisitor.cc
@@ -97,7 +97,7 @@ namespace detail {
         afwImage::Image<double> kImage(_spatialKernel->getDimensions());
         double kSum = _spatialKernel->computeImage(kImage, false, 
                                                    kCandidate->getXCenter(), kCandidate->getYCenter());
-        boost::shared_ptr<afwMath::Kernel>
+        std::shared_ptr<afwMath::Kernel>
             kernelPtr(new afwMath::FixedKernel(kImage));
         /* </hack> */
         

--- a/src/BasisLists.cc
+++ b/src/BasisLists.cc
@@ -57,7 +57,7 @@ namespace diffim {
         afwMath::KernelList kernelBasisList;
         for (int row = 0; row < signedHeight; ++row) {
             for (int col = 0; col < signedWidth; ++col) {
-                boost::shared_ptr<afwMath::Kernel> 
+                std::shared_ptr<afwMath::Kernel> 
                     kernelPtr(new afwMath::DeltaFunctionKernel(width, height, afwGeom::Point2I(col,row)));
                 kernelBasisList.push_back(kernelPtr);
             }
@@ -117,7 +117,7 @@ namespace diffim {
                     /* for 0th order term, skip polynomial */
                     (void)kernel.computeImage(image, true);
                     if (n == 0) {
-                        boost::shared_ptr<afwMath::Kernel> 
+                        std::shared_ptr<afwMath::Kernel> 
                             kernelPtr(new afwMath::FixedKernel(image));
                         kernelBasisList.push_back(kernelPtr);
                         continue;
@@ -136,7 +136,7 @@ namespace diffim {
                                                       v/static_cast<double>(halfWidth));
                         }
                     }
-                    boost::shared_ptr<afwMath::Kernel> 
+                    std::shared_ptr<afwMath::Kernel> 
                         kernelPtr(new afwMath::FixedKernel(image));
                     kernelBasisList.push_back(kernelPtr);
                     polynomial.setParameter(n, 0.);
@@ -147,7 +147,7 @@ namespace diffim {
     }
     
     
-    boost::shared_ptr<Eigen::MatrixXd>
+    std::shared_ptr<Eigen::MatrixXd>
     makeRegularizationMatrix(
         lsst::pex::policy::Policy policy
         ) {
@@ -188,7 +188,7 @@ namespace diffim {
         float borderPenalty  = policy.getDouble("regularizationBorderPenalty");
         bool fitForBackground = policy.getBool("fitForBackground");
         
-        boost::shared_ptr<Eigen::MatrixXd> bMat;
+        std::shared_ptr<Eigen::MatrixXd> bMat;
         if (regularizationType == "centralDifference") {
             int stencil = policy.getInt("centralRegularizationStencil");
             bMat = makeCentralDifferenceMatrix(width, height, stencil, borderPenalty, fitForBackground);
@@ -201,14 +201,14 @@ namespace diffim {
             throw LSST_EXCEPT(pexExcept::Exception, "regularizationType not recognized");
         }
         
-        boost::shared_ptr<Eigen::MatrixXd> hMat (new Eigen::MatrixXd((*bMat).transpose() * (*bMat)));
+        std::shared_ptr<Eigen::MatrixXd> hMat (new Eigen::MatrixXd((*bMat).transpose() * (*bMat)));
         return hMat;
     }
     
    /** 
     * @brief Generate regularization matrix for delta function kernels
     */
-    boost::shared_ptr<Eigen::MatrixXd>
+    std::shared_ptr<Eigen::MatrixXd>
     makeCentralDifferenceMatrix(
         int width,
         int height,
@@ -305,14 +305,14 @@ namespace diffim {
             }
         }
         
-        boost::shared_ptr<Eigen::MatrixXd> bMatPtr (new Eigen::MatrixXd(bMat));
+        std::shared_ptr<Eigen::MatrixXd> bMatPtr (new Eigen::MatrixXd(bMat));
         return bMatPtr;
     }
     
    /** 
     * @brief Generate regularization matrix for delta function kernels
     */
-    boost::shared_ptr<Eigen::MatrixXd>
+    std::shared_ptr<Eigen::MatrixXd>
     makeForwardDifferenceMatrix(
         int width,
         int height,
@@ -404,7 +404,7 @@ namespace diffim {
             }
         }
         
-        boost::shared_ptr<Eigen::MatrixXd> bMatPtr (new Eigen::MatrixXd(bTot));
+        std::shared_ptr<Eigen::MatrixXd> bMatPtr (new Eigen::MatrixXd(bTot));
         return bMatPtr;
     }
     
@@ -457,7 +457,7 @@ namespace diffim {
             if (i == 0) {
                 /* Make sure that it is normalized to kSum 1. */
                 (void)kernelListIn[i]->computeImage(image0, true);
-                boost::shared_ptr<afwMath::Kernel> 
+                std::shared_ptr<afwMath::Kernel> 
                     kernelPtr(new afwMath::FixedKernel(image0));
                 kernelListOut.push_back(kernelPtr);
                 
@@ -500,7 +500,7 @@ namespace diffim {
             image /= std::sqrt(kSum);
             /* image.writeFits(str(boost::format("out_k%d.fits") % i));  */
 
-            boost::shared_ptr<afwMath::Kernel> 
+            std::shared_ptr<afwMath::Kernel> 
                 kernelPtr(new afwMath::FixedKernel(image));
             kernelListOut.push_back(kernelPtr);
         }
@@ -512,7 +512,7 @@ namespace diffim {
    /** 
     * @brief Generate regularization matrix for delta function kernels
     */
-    boost::shared_ptr<Eigen::MatrixXd>
+    std::shared_ptr<Eigen::MatrixXd>
     makeFiniteDifferenceRegularizationDeprecated(
         unsigned int width,
         unsigned int height,
@@ -779,7 +779,7 @@ namespace diffim {
             std::cout << bMat << std::endl;
         }
         
-        boost::shared_ptr<Eigen::MatrixXd> hMat (new Eigen::MatrixXd(bMat.transpose() * bMat));
+        std::shared_ptr<Eigen::MatrixXd> hMat (new Eigen::MatrixXd(bMat.transpose() * bMat));
         return hMat;
     }
     

--- a/src/BuildSingleKernelVisitor.cc
+++ b/src/BuildSingleKernelVisitor.cc
@@ -9,7 +9,7 @@
  * @ingroup ip_diffim
  */
 
-#include "boost/shared_ptr.hpp" 
+#include <memory>
 #include "Eigen/Core"
 
 #include "lsst/afw/math.h"
@@ -110,7 +110,7 @@ namespace detail {
         lsst::afw::math::KernelList const& basisList,   ///< List of basis kernels
             ///< for resulting LinearCombinationKernel
         lsst::pex::policy::Policy const& policy,  ///< Policy file directing behavior
-        boost::shared_ptr<Eigen::MatrixXd> hMat   ///< Regularization matrix
+        std::shared_ptr<Eigen::MatrixXd> hMat   ///< Regularization matrix
         ) :
         afwMath::CandidateVisitor(),
         _basisList(basisList),
@@ -283,13 +283,13 @@ namespace detail {
 
     template class BuildSingleKernelVisitor<PixelT>;
 
-    template boost::shared_ptr<BuildSingleKernelVisitor<PixelT> >
+    template std::shared_ptr<BuildSingleKernelVisitor<PixelT> >
     makeBuildSingleKernelVisitor<PixelT>(lsst::afw::math::KernelList const&,
                                          lsst::pex::policy::Policy const&);
 
-    template boost::shared_ptr<BuildSingleKernelVisitor<PixelT> >
+    template std::shared_ptr<BuildSingleKernelVisitor<PixelT> >
     makeBuildSingleKernelVisitor<PixelT>(lsst::afw::math::KernelList const&,
                                          lsst::pex::policy::Policy const&,
-                                         boost::shared_ptr<Eigen::MatrixXd>);
+                                         std::shared_ptr<Eigen::MatrixXd>);
 
 }}}} // end of namespace lsst::ip::diffim::detail

--- a/src/BuildSpatialKernelVisitor.cc
+++ b/src/BuildSpatialKernelVisitor.cc
@@ -9,7 +9,7 @@
  * @ingroup ip_diffim
  */
 
-#include "boost/shared_ptr.hpp" 
+#include <memory>
 #include "boost/timer.hpp" 
 
 #include "Eigen/Core"
@@ -113,7 +113,7 @@ namespace detail {
 
         /* */
 
-        _kernelSolution = boost::shared_ptr<SpatialKernelSolution>(
+        _kernelSolution = std::shared_ptr<SpatialKernelSolution>(
             new SpatialKernelSolution(basisList, spatialKernelFunction, background, policy));
     };
     

--- a/src/DipoleAlgorithms.cc
+++ b/src/DipoleAlgorithms.cc
@@ -37,7 +37,7 @@
 #   include "Minuit2/MnPrint.h"
 #endif
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "lsst/pex/exceptions.h"
 #include "lsst/pex/logging/Trace.h"
 #include "lsst/afw/image.h"

--- a/src/KernelCandidate.cc
+++ b/src/KernelCandidate.cc
@@ -100,13 +100,13 @@ namespace diffim {
     void KernelCandidate<PixelT>::build(
         lsst::afw::math::KernelList const& basisList
         ) {
-        build(basisList, boost::shared_ptr<Eigen::MatrixXd>());
+        build(basisList, std::shared_ptr<Eigen::MatrixXd>());
     }
 
     template <typename PixelT>
     void KernelCandidate<PixelT>::build(
         lsst::afw::math::KernelList const& basisList,
-        boost::shared_ptr<Eigen::MatrixXd> hMat
+        std::shared_ptr<Eigen::MatrixXd> hMat
         ) {
 
         /* Examine the policy for control over the variance estimate */
@@ -154,7 +154,7 @@ namespace diffim {
 
     template <typename PixelT>
     void KernelCandidate<PixelT>::_buildKernelSolution(lsst::afw::math::KernelList const& basisList,
-                                                       boost::shared_ptr<Eigen::MatrixXd> hMat)
+                                                       std::shared_ptr<Eigen::MatrixXd> hMat)
     {
         bool checkConditionNumber = _policy.getBool("checkConditionNumber");
         double maxConditionNumber = _policy.getDouble("maxConditionNumber");
@@ -177,7 +177,7 @@ namespace diffim {
                               "Using kernel regularization");
 
             if (_isInitialized) {
-                _kernelSolutionPca = boost::shared_ptr<StaticKernelSolution<PixelT> >(
+                _kernelSolutionPca = std::shared_ptr<StaticKernelSolution<PixelT> >(
                     new RegularizedKernelSolution<PixelT>(basisList, _fitForBackground, hMat, _policy)
                     );
                 _kernelSolutionPca->build(*(_templateMaskedImage->getImage()),
@@ -195,7 +195,7 @@ namespace diffim {
                 _kernelSolutionPca->solve();
             }
             else {
-                _kernelSolutionOrig = boost::shared_ptr<StaticKernelSolution<PixelT> >(
+                _kernelSolutionOrig = std::shared_ptr<StaticKernelSolution<PixelT> >(
                     new RegularizedKernelSolution<PixelT>(basisList, _fitForBackground, hMat, _policy)
                     );
                 _kernelSolutionOrig->build(*(_templateMaskedImage->getImage()),
@@ -218,7 +218,7 @@ namespace diffim {
             pexLog::TTrace<5>("lsst.ip.diffim.KernelCandidate.build",
                               "Not using kernel regularization");
             if (_isInitialized) {
-                _kernelSolutionPca = boost::shared_ptr<StaticKernelSolution<PixelT> >(
+                _kernelSolutionPca = std::shared_ptr<StaticKernelSolution<PixelT> >(
                     new StaticKernelSolution<PixelT>(basisList, _fitForBackground)
                     );
                 _kernelSolutionPca->build(*(_templateMaskedImage->getImage()),
@@ -236,7 +236,7 @@ namespace diffim {
                 _kernelSolutionPca->solve();
             }
             else {
-                _kernelSolutionOrig = boost::shared_ptr<StaticKernelSolution<PixelT> >(
+                _kernelSolutionOrig = std::shared_ptr<StaticKernelSolution<PixelT> >(
                     new StaticKernelSolution<PixelT>(basisList, _fitForBackground)
                     );
                 _kernelSolutionOrig->build(*(_templateMaskedImage->getImage()),
@@ -371,7 +371,7 @@ namespace diffim {
     }
 
     template <typename PixelT>
-    boost::shared_ptr<StaticKernelSolution<PixelT> > KernelCandidate<PixelT>::getKernelSolution(
+    std::shared_ptr<StaticKernelSolution<PixelT> > KernelCandidate<PixelT>::getKernelSolution(
         CandidateSwitch cand) const {
         if (cand == KernelCandidate::ORIG) {
             if (_kernelSolutionOrig)

--- a/src/KernelCandidateDetection.cc
+++ b/src/KernelCandidateDetection.cc
@@ -92,7 +92,7 @@ namespace diffim {
         _footprints.clear();
 
         // List of Footprints
-        boost::shared_ptr<std::vector<afwDetect::Footprint::Ptr> > footprintListInPtr;
+        std::shared_ptr<std::vector<afwDetect::Footprint::Ptr> > footprintListInPtr;
 
         // Find detections
         afwDetect::Threshold threshold = 

--- a/src/KernelPca.cc
+++ b/src/KernelPca.cc
@@ -55,7 +55,7 @@ namespace detail {
      */
     template<typename PixelT>
     KernelPcaVisitor<PixelT>::KernelPcaVisitor(
-        boost::shared_ptr<KernelPca<ImageT> > imagePca ///< Set of Images to initialise
+        std::shared_ptr<KernelPca<ImageT> > imagePca ///< Set of Images to initialise
         ) :
         afwMath::CandidateVisitor(),
         _imagePca(imagePca),

--- a/src/KernelSumVisitor.cc
+++ b/src/KernelSumVisitor.cc
@@ -172,7 +172,7 @@ namespace detail {
 
     template class KernelSumVisitor<PixelT>;
 
-    template boost::shared_ptr<KernelSumVisitor<PixelT> > 
+    template std::shared_ptr<KernelSumVisitor<PixelT> > 
     makeKernelSumVisitor<PixelT>(lsst::pex::policy::Policy const&);
 
 }}}} // end of namespace lsst::ip::diffim::detail


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory