### PR TITLE
fix variance calculation to use masks

### DIFF
--- a/python/lsst/ip/diffim/dipoleFitTask.py
+++ b/python/lsst/ip/diffim/dipoleFitTask.py
@@ -90,7 +90,10 @@ class DipoleFitPluginConfig(measBase.SingleFramePluginConfig):
 
 
 class DipoleFitTaskConfig(measBase.SingleFrameMeasurementConfig):
-    """!Measurement of detected diaSources as dipoles"""
+    """!Measurement of detected diaSources as dipoles
+
+    Currently we keep the "old" DipoleMeasurement algorithms turned on.
+    """
 
     def setDefaults(self):
         measBase.SingleFrameMeasurementConfig.setDefaults(self)
@@ -101,7 +104,8 @@ class DipoleFitTaskConfig(measBase.SingleFrameMeasurementConfig):
                               "base_PsfFlux",
                               "ip_diffim_NaiveDipoleCentroid",
                               "ip_diffim_NaiveDipoleFlux",
-                              "ip_diffim_PsfDipoleFlux"
+                              "ip_diffim_PsfDipoleFlux",
+                              "ip_diffim_ClassificationDipole"
                               ]
 
         self.slots.calibFlux = None


### PR DESCRIPTION
fix normalization of correction kernel
remove commented print statements
add coordinate parameters to `run` for testing
update test for stricter tolerance after bug fix
turn on old ClassificationDipole again
add options to DecorrelateALKerneltask.run()
change all sig**2 to variance
Fix mixup of var1 and var2 for science and template