### PR TITLE
DM-6999: Update for the logging changes in the task framework

### DIFF
--- a/python/lsst/ip/diffim/dipoleMeasurement.py
+++ b/python/lsst/ip/diffim/dipoleMeasurement.py
@@ -23,8 +23,8 @@ import numpy as np
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
 import lsst.afw.detection as afwDetect
-import lsst.pex.logging as pexLog
 import lsst.pex.config as pexConfig
+from lsst.log import Log
 import lsst.meas.deblender.baseline as deblendBaseline
 from lsst.meas.base.pluginRegistry import register
 from lsst.meas.base import SingleFrameMeasurementTask, SingleFrameMeasurementConfig, \
@@ -449,8 +449,8 @@ class DipoleDeblender(object):
 
         # Always deblend as Psf
         self.psfChisqCut1 = self.psfChisqCut2 = self.psfChisqCut2b = np.inf
-        self.log = pexLog.Log(pexLog.Log.getDefaultLog(),
-                              'lsst.ip.diffim.DipoleDeblender', pexLog.Log.INFO)
+        self.log = Log.getLogger('lsst.ip.diffim.DipoleDeblender')
+        self.log.setLevel(Log.INFO)
         self.sigma2fwhm = 2. * np.sqrt(2. * np.log(2.))
 
     def __call__(self, source, exposure):
@@ -502,7 +502,7 @@ class DipoleDeblender(object):
                 fpres.peaks.append(pkres)
 
             for pki,(pk,pkres,pkF) in enumerate(zip(dpeaks, fpres.peaks, peaksF)):
-                self.log.logdebug('Peak %i' % pki)
+                self.log.debug('Peak %i', pki)
                 deblendBaseline._fitPsf(fp, fmask, pk, pkF, pkres, fbb, dpeaks, peaksF, self.log,
                                          cpsf, psfFwhmPix,
                                          subimage.getMaskedImage().getImage(),
@@ -521,11 +521,11 @@ class DipoleDeblender(object):
             else:
                 suffix = "neg"
             c = peak.psfFitCenter
-            self.log.info("deblended.centroid.dipole.psf.%s %f %f" % (
-                suffix, c[0], c[1]))
-            self.log.info("deblended.chi2dof.dipole.%s %f" % (
-                suffix, peak.psfFitChisq / peak.psfFitDof))
-            self.log.info("deblended.flux.dipole.psf.%s %f" % (
-                suffix, peak.psfFitFlux * np.sum(peak.templateImage.getArray())))
+            self.log.info("deblended.centroid.dipole.psf.%s %f %f",
+                suffix, c[0], c[1])
+            self.log.info("deblended.chi2dof.dipole.%s %f",
+                suffix, peak.psfFitChisq / peak.psfFitDof)
+            self.log.info("deblended.flux.dipole.psf.%s %f",
+                suffix, peak.psfFitFlux * np.sum(peak.templateImage.getArray()))
             peakList.append(peak.peak)
         return deblendedSource

--- a/python/lsst/ip/diffim/imagePsfMatch.py
+++ b/python/lsst/ip/diffim/imagePsfMatch.py
@@ -445,7 +445,7 @@ And finally provide some optional debugging displays:
             lsstDebug.frame += 1
 
         if templateFwhmPix and scienceFwhmPix:
-            self.log.info("Matching Psf FWHM %.2f -> %.2f pix" % (templateFwhmPix, scienceFwhmPix))
+            self.log.info("Matching Psf FWHM %.2f -> %.2f pix", templateFwhmPix, scienceFwhmPix)
 
         if self.kConfig.useBicForKernelBasis:
             tmpKernelCellSet = self._buildCellSet(templateMaskedImage,
@@ -744,7 +744,7 @@ And finally provide some optional debugging displays:
             smi  = afwImage.MaskedImageF(scienceMaskedImage, bbox)
             cand = diffimLib.makeKernelCandidate(cand['source'], tmi, smi, policy)
 
-            self.log.logdebug("Candidate %d at %f, %f" % (cand.getId(), cand.getXCenter(), cand.getYCenter()))
+            self.log.debug("Candidate %d at %f, %f", cand.getId(), cand.getXCenter(), cand.getYCenter())
             kernelCellSet.insertCandidate(cand)
 
         return kernelCellSet
@@ -770,12 +770,12 @@ And finally provide some optional debugging displays:
         templateLimit  = templateWcs.pixelToSky(afwGeom.Point2D(templateBBox.getEnd()))
         scienceLimit   = scienceWcs.pixelToSky(afwGeom.Point2D(scienceBBox.getEnd()))
 
-        self.log.info("Template Wcs : %f,%f -> %f,%f" %
-                      (templateOrigin[0], templateOrigin[1],
-                       templateLimit[0], templateLimit[1]))
-        self.log.info("Science Wcs : %f,%f -> %f,%f" %
-                      (scienceOrigin[0], scienceOrigin[1],
-                       scienceLimit[0], scienceLimit[1]))
+        self.log.info("Template Wcs : %f,%f -> %f,%f",
+                      templateOrigin[0], templateOrigin[1],
+                      templateLimit[0], templateLimit[1])
+        self.log.info("Science Wcs : %f,%f -> %f,%f",
+                      scienceOrigin[0], scienceOrigin[1],
+                      scienceLimit[0], scienceLimit[1])
 
         templateBBox = afwGeom.Box2D(templateOrigin.getPosition(), templateLimit.getPosition())
         scienceBBox  = afwGeom.Box2D(scienceOrigin.getPosition(), scienceLimit.getPosition())

--- a/python/lsst/ip/diffim/modelPsfMatch.py
+++ b/python/lsst/ip/diffim/modelPsfMatch.py
@@ -259,7 +259,7 @@ And finally provide optional debugging display of the Psf-matched (via the Psf m
 
         maskedImage = exposure.getMaskedImage()
 
-        self.log.log(pexLog.Log.INFO, "compute Psf-matching kernel")
+        self.log.info("compute Psf-matching kernel")
         kernelCellSet = self._buildCellSet(exposure, referencePsfModel)
         width, height = referencePsfModel.getLocalKernel().getDimensions()
         psfAttr1 = measAlg.PsfAttributes(exposure.getPsf(), width//2, height//2)
@@ -281,7 +281,7 @@ And finally provide optional debugging display of the Psf-matched (via the Psf m
             kParameters[0] = kernelSum
             psfMatchingKernel.setKernelParameters(kParameters)
 
-        self.log.log(pexLog.Log.INFO, "Psf-match science exposure to reference")
+        self.log.info("Psf-match science exposure to reference")
         psfMatchedExposure = afwImage.ExposureF(exposure.getBBox(), exposure.getWcs())
         psfMatchedExposure.setFilter(exposure.getFilter())
         psfMatchedExposure.setCalib(exposure.getCalib())
@@ -292,7 +292,7 @@ And finally provide optional debugging display of the Psf-matched (via the Psf m
         doNormalize = True
         afwMath.convolve(psfMatchedMaskedImage, maskedImage, psfMatchingKernel, doNormalize)
 
-        self.log.log(pexLog.Log.INFO, "done")
+        self.log.info("done")
         return pipeBase.Struct(psfMatchedExposure=psfMatchedExposure,
                                psfMatchingKernel=psfMatchingKernel,
                                kernelCellSet=kernelCellSet,


### PR DESCRIPTION
Tasks' logs are switched from lsst.pex.logging to lsst.log