### PR TITLE
DM-7566: Add missing pex_logging dependency

### DIFF
--- a/ups/ip_diffim.cfg
+++ b/ups/ip_diffim.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["meas_base", "afw", "numpy", "minuit2"],
+    "required": ["meas_base", "afw", "numpy", "minuit2", "pex_logging"],
     "buildRequired": ["boost_test", "swig"],
 }
 


### PR DESCRIPTION
pex.logging is used in this package but not missing in ups