### PR TITLE
DM-7611: Implement spatially varying decorrelation kernel in ip_diffim

### DIFF
--- a/tests/testImageMapReduce.py
+++ b/tests/testImageMapReduce.py
@@ -111,9 +111,9 @@ class AddAmountImageMapperSubtask(ImageMapperSubtask):
 
         Parameters
         ----------
-        subExposure : `afwImage.ExposureF`
+        subExposure : `afwImage.Exposure`
             Input `subExposure` upon which to operate
-        expandedSubExp : `afwImage.ExposureF`
+        expandedSubExp : `afwImage.Exposure`
             Input expanded subExposure (not used here)
         fullBBox : `afwGeom.BoundingBox`
             Bounding box of original exposure (not used here)
@@ -156,9 +156,9 @@ class GetMeanImageMapperSubtask(ImageMapperSubtask):
 
         Parameters
         ----------
-        subExposure : `afwImage.ExposureF`
+        subExposure : `afwImage.Exposure`
             Input `subExposure` upon which to operate
-        expandedSubExp : `afwImage.ExposureF`
+        expandedSubExp : `afwImage.Exposure`
             Input expanded subExposure (not used here)
         fullBBox : `afwGeom.BoundingBox`
             Bounding box of original exposure (not used here)


### PR DESCRIPTION
…tion

Additional necessary improvements:

- Update ImageMapReduceTask to use Exposures other than ExposureF
- Update ImageReducerSubtask to correctly propagate masks
- Docstring fixes in imageMapReduce.py
- Additional unit tests and refactoring of testImageDecorrelation.py
  to test decorrelation via two different tasks