### PR TITLE
DM-4639: modernize afw code and reduce doxygen errors

### DIFF
--- a/examples/pixelAccess.cc
+++ b/examples/pixelAccess.cc
@@ -116,7 +116,7 @@ Eigen::MatrixXd test(afwImage::Image<ImageT> varianceEstimate,
         std::vector<std::shared_ptr<afwImage::Image<ImageT> > > imageList(nParameters);
         typename std::vector<std::shared_ptr<afwImage::Image<ImageT> > >::iterator citer=imageList.begin();
         for (int i = 1; citer != imageList.end(); ++citer, ++i) {
-            *citer = typename afwImage::Image<ImageT>::Ptr(
+            *citer = std::shared_ptr<afwImage::Image<ImageT>>(
                 new afwImage::Image<ImageT>(varianceEstimate.getDimensions())
                 );
             **citer = i; /* give it a value */

--- a/examples/spatialKernel.cc
+++ b/examples/spatialKernel.cc
@@ -49,7 +49,7 @@ int main() {
         afwMath::Kernel::SpatialFunctionPtr spatialFunction(spatialKernelFunction->clone());
         spatialFunctionList.push_back(spatialFunction);
     }
-    afwMath::LinearCombinationKernel::Ptr spatialKernel(
+    std::shared_ptr<afwMath::LinearCombinationKernel> spatialKernel(
         new afwMath::LinearCombinationKernel(basisList, spatialFunctionList)
         );
     /* Set up some fake terms */
@@ -65,11 +65,11 @@ int main() {
     spatialKernel->setSpatialParameters(kCoeffs);
     
     unsigned int loc = 50;
-    afwImage::MaskedImage<PixelT>::Ptr mimg1(
+    std::shared_ptr<afwImage::MaskedImage<PixelT>> mimg1(
         new afwImage::MaskedImage<PixelT>(afwGeom::Extent2I(100,100))
         );
     *mimg1->at(loc, loc) = afwImage::MaskedImage<PixelT>::Pixel(1, 0x0, 1);
-    afwImage::MaskedImage<PixelT>::Ptr mimg2(
+    std::shared_ptr<afwImage::MaskedImage<PixelT>> mimg2(
         new afwImage::MaskedImage<PixelT>(mimg1->getDimensions())
         );
     afwMath::convolve(*mimg2, *mimg1, *spatialKernel, false);

--- a/include/lsst/ip/diffim/AssessSpatialKernelVisitor.h
+++ b/include/lsst/ip/diffim/AssessSpatialKernelVisitor.h
@@ -29,7 +29,7 @@ namespace detail {
         typedef std::shared_ptr<AssessSpatialKernelVisitor<PixelT> > Ptr;
 
         AssessSpatialKernelVisitor(
-            lsst::afw::math::LinearCombinationKernel::Ptr spatialKernel,   ///< Spatially varying kernel 
+            std::shared_ptr<lsst::afw::math::LinearCombinationKernel> spatialKernel,   ///< Spatially varying kernel
             lsst::afw::math::Kernel::SpatialFunctionPtr spatialBackground, ///< Spatially varying background
             lsst::pex::policy::Policy const& policy                        ///< Policy file 
             );
@@ -43,7 +43,7 @@ namespace detail {
         void processCandidate(lsst::afw::math::SpatialCellCandidate *candidate);
 
     private:
-        lsst::afw::math::LinearCombinationKernel::Ptr _spatialKernel;   ///< Spatial kernel function
+        std::shared_ptr<lsst::afw::math::LinearCombinationKernel> _spatialKernel;   ///< Spatial kernel function
         lsst::afw::math::Kernel::SpatialFunctionPtr _spatialBackground; ///< Spatial background function
         lsst::pex::policy::Policy _policy;            ///< Policy controlling behavior
         ImageStatistics<PixelT> _imstats;     ///< To calculate statistics of difference image
@@ -58,12 +58,12 @@ namespace detail {
     template<typename PixelT>
     std::shared_ptr<AssessSpatialKernelVisitor<PixelT> >
     makeAssessSpatialKernelVisitor(
-        lsst::afw::math::LinearCombinationKernel::Ptr spatialKernel,   
+        std::shared_ptr<lsst::afw::math::LinearCombinationKernel> spatialKernel,
         lsst::afw::math::Kernel::SpatialFunctionPtr spatialBackground, 
         lsst::pex::policy::Policy const& policy                        
          ) {
 
-        return typename AssessSpatialKernelVisitor<PixelT>::Ptr(
+        return std::shared_ptr<AssessSpatialKernelVisitor<PixelT>>(
             new AssessSpatialKernelVisitor<PixelT>(spatialKernel, spatialBackground, policy)
             );
     }

--- a/include/lsst/ip/diffim/BuildSingleKernelVisitor.h
+++ b/include/lsst/ip/diffim/BuildSingleKernelVisitor.h
@@ -79,7 +79,7 @@ namespace detail {
         lsst::pex::policy::Policy const& policy
         ) {
 
-        return typename BuildSingleKernelVisitor<PixelT>::Ptr(
+        return std::shared_ptr<BuildSingleKernelVisitor<PixelT>>(
             new BuildSingleKernelVisitor<PixelT>(basisList, policy)
             );
     }
@@ -92,7 +92,7 @@ namespace detail {
         Eigen::MatrixXd const & hMat
         ) {
 
-        return typename BuildSingleKernelVisitor<PixelT>::Ptr(
+        return std::shared_ptr<BuildSingleKernelVisitor<PixelT>>(
             new BuildSingleKernelVisitor<PixelT>(basisList, policy, hMat)
             );
     }

--- a/include/lsst/ip/diffim/BuildSpatialKernelVisitor.h
+++ b/include/lsst/ip/diffim/BuildSpatialKernelVisitor.h
@@ -42,7 +42,7 @@ namespace detail {
   
         inline std::shared_ptr<SpatialKernelSolution> getKernelSolution() {return _kernelSolution;}
 
-        std::pair<lsst::afw::math::LinearCombinationKernel::Ptr, 
+        std::pair<std::shared_ptr<lsst::afw::math::LinearCombinationKernel>,
                   lsst::afw::math::Kernel::SpatialFunctionPtr> getSolutionPair();
 
     private:
@@ -58,7 +58,7 @@ namespace detail {
         lsst::pex::policy::Policy policy
         ) {
 
-        return typename BuildSpatialKernelVisitor<PixelT>::Ptr(
+        return std::shared_ptr<BuildSpatialKernelVisitor<PixelT>>(
             new BuildSpatialKernelVisitor<PixelT>(basisList, regionBBox, policy)
             );
     }

--- a/include/lsst/ip/diffim/KernelCandidate.h
+++ b/include/lsst/ip/diffim/KernelCandidate.h
@@ -102,7 +102,7 @@ namespace diffim {
          * @brief Return results of kernel solution
          *
          */
-        afw::math::Kernel::Ptr getKernel(CandidateSwitch cand) const;
+        std::shared_ptr<afw::math::Kernel> getKernel(CandidateSwitch cand) const;
         double getBackground(CandidateSwitch cand) const;
         double getKsum(CandidateSwitch cand) const;
         PTR(ImageT) getKernelImage(CandidateSwitch cand) const;
@@ -120,7 +120,7 @@ namespace diffim {
          * @note Useful for spatial modeling
          */
         afw::image::MaskedImage<PixelT> getDifferenceImage(
-            afw::math::Kernel::Ptr kernel,
+            std::shared_ptr<afw::math::Kernel> kernel,
             double background
             );
 
@@ -222,7 +222,7 @@ namespace diffim {
                         std::shared_ptr<afw::image::MaskedImage<PixelT> > const& scienceMaskedImage,
                         pex::policy::Policy const& policy){
 
-        return typename KernelCandidate<PixelT>::Ptr(new KernelCandidate<PixelT>(xCenter, yCenter,
+        return std::shared_ptr<KernelCandidate<PixelT>>(new KernelCandidate<PixelT>(xCenter, yCenter,
                                                                                  templateMaskedImage,
                                                                                  scienceMaskedImage,
                                                                                  policy));
@@ -246,10 +246,10 @@ namespace diffim {
                         std::shared_ptr<afw::image::MaskedImage<PixelT> > const& scienceMaskedImage,
                         pex::policy::Policy const& policy){
 
-        return typename KernelCandidate<PixelT>::Ptr(new KernelCandidate<PixelT>(source,
-                                                                                 templateMaskedImage,
-                                                                                 scienceMaskedImage,
-                                                                                 policy));
+        return std::shared_ptr<KernelCandidate<PixelT>>(new KernelCandidate<PixelT>(source,
+                                                                                    templateMaskedImage,
+                                                                                    scienceMaskedImage,
+                                                                                    policy));
     }
 
 

--- a/include/lsst/ip/diffim/KernelPca.h
+++ b/include/lsst/ip/diffim/KernelPca.h
@@ -57,7 +57,7 @@ namespace detail {
     template<typename PixelT>
     std::shared_ptr<KernelPcaVisitor<PixelT> >
     makeKernelPcaVisitor(std::shared_ptr<KernelPca<typename KernelPcaVisitor<PixelT>::ImageT> > imagePca) {
-        return typename KernelPcaVisitor<PixelT>::Ptr(new KernelPcaVisitor<PixelT>(imagePca));
+        return std::shared_ptr<KernelPcaVisitor<PixelT>>(new KernelPcaVisitor<PixelT>(imagePca));
     };
 
 }}}} // end of namespace lsst::ip::diffim::detail

--- a/include/lsst/ip/diffim/KernelSolution.h
+++ b/include/lsst/ip/diffim/KernelSolution.h
@@ -94,8 +94,8 @@ namespace diffim {
         virtual void build(lsst::afw::image::Image<InputT> const &templateImage,
                            lsst::afw::image::Image<InputT> const &scienceImage,
                            lsst::afw::image::Image<lsst::afw::image::VariancePixel> const &varianceEstimate);
-        virtual lsst::afw::math::Kernel::Ptr getKernel();
-        virtual lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>::Ptr makeKernelImage();
+        virtual std::shared_ptr<lsst::afw::math::Kernel> getKernel();
+        virtual std::shared_ptr<lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>> makeKernelImage();
         virtual double getBackground();
         virtual double getKsum();
         virtual std::pair<std::shared_ptr<lsst::afw::math::Kernel>, double> getSolutionPair();
@@ -105,7 +105,7 @@ namespace diffim {
         Eigen::VectorXd _iVec;               ///< Vectorized I
         Eigen::VectorXd _ivVec;              ///< Inverse variance
 
-        lsst::afw::math::Kernel::Ptr _kernel;                   ///< Derived single-object convolution kernel
+        std::shared_ptr<lsst::afw::math::Kernel> _kernel;                   ///< Derived single-object convolution kernel
         double _background;                                     ///< Derived differential background estimate
         double _kSum;                                           ///< Derived kernel sum
 
@@ -188,15 +188,15 @@ namespace diffim {
                            Eigen::VectorXd const& wVec);
 
         void solve();
-        lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>::Ptr makeKernelImage(lsst::afw::geom::Point2D const& pos);
-        std::pair<lsst::afw::math::LinearCombinationKernel::Ptr,
+        std::shared_ptr<lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>> makeKernelImage(lsst::afw::geom::Point2D const& pos);
+        std::pair<std::shared_ptr<lsst::afw::math::LinearCombinationKernel>,
                   lsst::afw::math::Kernel::SpatialFunctionPtr> getSolutionPair();
 
     private:
         lsst::afw::math::Kernel::SpatialFunctionPtr _spatialKernelFunction; ///< Spatial function for Kernel
         bool _constantFirstTerm;                                            ///< Is the first term constant
 
-        lsst::afw::math::LinearCombinationKernel::Ptr _kernel;   ///< Spatial convolution kernel
+        std::shared_ptr<lsst::afw::math::LinearCombinationKernel> _kernel;   ///< Spatial convolution kernel
         lsst::afw::math::Kernel::SpatialFunctionPtr _background; ///< Spatial background model
         double _kSum;                                            ///< Derived kernel sum
 

--- a/include/lsst/ip/diffim/KernelSumVisitor.h
+++ b/include/lsst/ip/diffim/KernelSumVisitor.h
@@ -58,7 +58,7 @@ namespace detail {
     template<typename PixelT>
     std::shared_ptr<KernelSumVisitor<PixelT> >
     makeKernelSumVisitor(lsst::pex::policy::Policy const& policy) {
-        return typename KernelSumVisitor<PixelT>::Ptr(new KernelSumVisitor<PixelT>(policy));
+        return std::shared_ptr<KernelSumVisitor<PixelT>>(new KernelSumVisitor<PixelT>(policy));
     }
 
 }}}} // end of namespace lsst::ip::diffim::detail

--- a/src/AssessSpatialKernelVisitor.cc
+++ b/src/AssessSpatialKernelVisitor.cc
@@ -52,7 +52,7 @@ namespace detail {
      */
     template<typename PixelT>
     AssessSpatialKernelVisitor<PixelT>::AssessSpatialKernelVisitor(
-        lsst::afw::math::LinearCombinationKernel::Ptr spatialKernel,   ///< Spatially varying kernel model
+        std::shared_ptr<lsst::afw::math::LinearCombinationKernel> spatialKernel,   ///< Spatially varying kernel model
         lsst::afw::math::Kernel::SpatialFunctionPtr spatialBackground, ///< Spatially varying backgound model
         lsst::pex::policy::Policy const& policy                        ///< Policy file directing behavior
         ) : 

--- a/src/BuildSingleKernelVisitor.cc
+++ b/src/BuildSingleKernelVisitor.cc
@@ -42,7 +42,7 @@ namespace detail {
      * @brief Builds the convolution kernel for a given candidate
      *
      * @code
-        Policy::Ptr policy(new Policy);
+        std::shared_ptr<Policy> policy(new Policy);
         policy->set("constantVarianceWeighting", false);
         policy->set("iterateSingleKernel", false);
         policy->set("singleKernelClipping", true);

--- a/src/BuildSpatialKernelVisitor.cc
+++ b/src/BuildSpatialKernelVisitor.cc
@@ -43,7 +43,7 @@ namespace detail {
      * @brief Creates a spatial kernel and background from a list of candidates
      *
      * @code
-        Policy::Ptr policy(new Policy);
+        std::shared_ptr<Policy> policy(new Policy);
         policy->set("spatialKernelOrder", spatialKernelOrder);
         policy->set("spatialBgOrder", spatialBgOrder);
         policy->set("kernelBasisSet", "delta-function");
@@ -53,7 +53,7 @@ namespace detail {
                                                                       *policy);
         kernelCells.visitCandidates(&spatialKernelFitter, nStarPerCell);
         spatialKernelFitter.solveLinearEquation();
-        std::pair<afwMath::LinearCombinationKernel::Ptr, 
+        std::pair<std::shared_ptr<afwMath::LinearCombinationKernel>,
             afwMath::Kernel::SpatialFunctionPtr> kb = spatialKernelFitter.getKernelSolution();
         spatialKernel     = kb.first;
         spatialBackground = kb.second; 
@@ -159,7 +159,7 @@ namespace detail {
     }
 
     template<typename PixelT>
-    std::pair<afwMath::LinearCombinationKernel::Ptr, afwMath::Kernel::SpatialFunctionPtr>
+    std::pair<std::shared_ptr<afwMath::LinearCombinationKernel>, afwMath::Kernel::SpatialFunctionPtr>
     BuildSpatialKernelVisitor<PixelT>::getSolutionPair() {
         return _kernelSolution->getSolutionPair();
     }

--- a/src/KernelCandidate.cc
+++ b/src/KernelCandidate.cc
@@ -255,7 +255,7 @@ namespace diffim {
     }
 
     template <typename PixelT>
-    lsst::afw::math::Kernel::Ptr KernelCandidate<PixelT>::getKernel(CandidateSwitch cand) const {
+    std::shared_ptr<lsst::afw::math::Kernel> KernelCandidate<PixelT>::getKernel(CandidateSwitch cand) const {
         if (cand == KernelCandidate::ORIG) {
             if (_kernelSolutionOrig)
                 return _kernelSolutionOrig->getKernel();
@@ -336,7 +336,7 @@ namespace diffim {
     }
 
     template <typename PixelT>
-    KernelCandidate<PixelT>::ImageT::Ptr KernelCandidate<PixelT>::getKernelImage(
+    std::shared_ptr<typename KernelCandidate<PixelT>::ImageT> KernelCandidate<PixelT>::getKernelImage(
         CandidateSwitch cand) const {
         if (cand == KernelCandidate::ORIG) {
             if (_kernelSolutionOrig)
@@ -364,7 +364,7 @@ namespace diffim {
     }
 
     template <typename PixelT>
-    KernelCandidate<PixelT>::ImageT::ConstPtr KernelCandidate<PixelT>::getImage() const {
+    std::shared_ptr<typename KernelCandidate<PixelT>::ImageT const> KernelCandidate<PixelT>::getImage() const {
         return getKernelImage(KernelCandidate::ORIG);
     }
 
@@ -430,7 +430,7 @@ namespace diffim {
 
     template <typename PixelT>
     lsst::afw::image::MaskedImage<PixelT> KernelCandidate<PixelT>::getDifferenceImage(
-        lsst::afw::math::Kernel::Ptr kernel,
+        std::shared_ptr<lsst::afw::math::Kernel> kernel,
         double background
         ) {
         /* Make diffim and set chi2 from result */

--- a/src/KernelPca.cc
+++ b/src/KernelPca.cc
@@ -65,11 +65,11 @@ namespace detail {
     lsst::afw::math::KernelList KernelPcaVisitor<PixelT>::getEigenKernels() {
         afwMath::KernelList kernelList;
 
-        std::vector<typename ImageT::Ptr> eigenImages = _imagePca->getEigenImages();
+        std::vector<std::shared_ptr<ImageT>> eigenImages = _imagePca->getEigenImages();
         int ncomp = eigenImages.size();
 
         if (_mean) {
-            kernelList.push_back(afwMath::Kernel::Ptr(
+            kernelList.push_back(std::shared_ptr<afwMath::Kernel>(
                                      new afwMath::FixedKernel(
                                          afwImage::Image<afwMath::Kernel::Pixel>
                                          (*_mean, true))));
@@ -77,7 +77,7 @@ namespace detail {
         for (int i = 0; i < ncomp; i++) {
             afwImage::Image<afwMath::Kernel::Pixel> img = 
                 afwImage::Image<afwMath::Kernel::Pixel>(*eigenImages[i], true);
-            kernelList.push_back(afwMath::Kernel::Ptr(
+            kernelList.push_back(std::shared_ptr<afwMath::Kernel>(
                                      new afwMath::FixedKernel(img)
                                      ));
         }

--- a/src/KernelSolution.cc
+++ b/src/KernelSolution.cc
@@ -210,7 +210,7 @@ namespace diffim {
     };
 
     template <typename InputT>
-    lsst::afw::math::Kernel::Ptr StaticKernelSolution<InputT>::getKernel() {
+    std::shared_ptr<lsst::afw::math::Kernel> StaticKernelSolution<InputT>::getKernel() {
         if (_solvedBy == KernelSolution::NONE) {
             throw LSST_EXCEPT(pexExcept::Exception, "Kernel not solved; cannot return solution");
         }
@@ -218,11 +218,11 @@ namespace diffim {
     }
 
     template <typename InputT>
-    lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>::Ptr StaticKernelSolution<InputT>::makeKernelImage() {
+    std::shared_ptr<lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>> StaticKernelSolution<InputT>::makeKernelImage() {
         if (_solvedBy == KernelSolution::NONE) {
             throw LSST_EXCEPT(pexExcept::Exception, "Kernel not solved; cannot return image");
         }
-        afwImage::Image<afwMath::Kernel::Pixel>::Ptr image(
+        std::shared_ptr<afwImage::Image<afwMath::Kernel::Pixel>> image(
             new afwImage::Image<afwMath::Kernel::Pixel>(_kernel->getDimensions())
             );
         (void)_kernel->computeImage(*image, false);
@@ -440,7 +440,7 @@ namespace diffim {
         }
         _kernel->setKernelParameters(kValues);
 
-        ImageT::Ptr image (
+        std::shared_ptr<ImageT> image (
             new ImageT(_kernel->getDimensions())
             );
         _kSum  = _kernel->computeImage(*image, false);
@@ -1321,7 +1321,7 @@ namespace diffim {
         this->_mMat = mMat;
         this->_bVec = bVec;
 
-        _kernel = afwMath::LinearCombinationKernel::Ptr(
+        _kernel = std::shared_ptr<afwMath::LinearCombinationKernel>(
             new afwMath::LinearCombinationKernel(basisList, *_spatialKernelFunction)
             );
 
@@ -1445,11 +1445,11 @@ namespace diffim {
 
     }
 
-    lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>::Ptr SpatialKernelSolution::makeKernelImage(afwGeom::Point2D const& pos) {
+    std::shared_ptr<lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel>> SpatialKernelSolution::makeKernelImage(afwGeom::Point2D const& pos) {
         if (_solvedBy == KernelSolution::NONE) {
             throw LSST_EXCEPT(pexExcept::Exception, "Kernel not solved; cannot return image");
         }
-        afwImage::Image<afwMath::Kernel::Pixel>::Ptr image(
+        std::shared_ptr<afwImage::Image<afwMath::Kernel::Pixel>> image(
             new afwImage::Image<afwMath::Kernel::Pixel>(_kernel->getDimensions())
             );
         (void)_kernel->computeImage(*image, false, pos[0], pos[1]);
@@ -1474,7 +1474,7 @@ namespace diffim {
         _setKernel();
     }
 
-    std::pair<afwMath::LinearCombinationKernel::Ptr,
+    std::pair<std::shared_ptr<afwMath::LinearCombinationKernel>,
             afwMath::Kernel::SpatialFunctionPtr> SpatialKernelSolution::getSolutionPair() {
         if (_solvedBy == KernelSolution::NONE) {
             throw LSST_EXCEPT(pexExcept::Exception, "Kernel not solved; cannot return solution");
@@ -1541,7 +1541,7 @@ namespace diffim {
         }
 
         /* Set kernel Sum */
-        ImageT::Ptr image (new ImageT(_kernel->getDimensions()));
+        std::shared_ptr<ImageT> image (new ImageT(_kernel->getDimensions()));
         _kSum  = _kernel->computeImage(*image, false);
 
         /* Set the background coefficients */

--- a/src/KernelSumVisitor.cc
+++ b/src/KernelSumVisitor.cc
@@ -34,7 +34,7 @@ namespace detail {
      * @brief A class to accumulate kernel sums across SpatialCells 
      *
      * @code
-        Policy::Ptr policy(new Policy);
+        std::shared_ptr<Policy> policy(new Policy);
         policy->set("kernelSumClipping", false);
         policy->set("maxKsumSigma", 3.0);
      


### PR DESCRIPTION
[DM-4639](https://jira.lsstcorp.org/browse/DM-4639) requires that `afw` components no longer have type members `Ptr` and `ConstPtr` representing shared pointers to those types. This is a breaking API change that requires changes to downstream code.

For clarity, no unnecessary changes changes were made to this package, not even a `clang-format` pass.