### PR TITLE
DM-11620: Make test_dipoleFitter.py more robust

### DIFF
--- a/tests/test_dipoleFitter.py
+++ b/tests/test_dipoleFitter.py
@@ -59,7 +59,6 @@ class DipoleTestImage(object):
         @param flux iterable fluxes of pos/neg lobes of dipole(s)
         @param gradientParams iterable three parameters for linear background gradient
         """
-        np.random.seed(666)
         self.display = False  # Display (plot) the output dipole thumbnails (matplotlib)
         self.verbose = False  # be verbose during fitting
 
@@ -104,7 +103,7 @@ class DipoleFitTest(lsst.utils.tests.TestCase):
         input values for both dipoles in the image.
         """
         params = DipoleTestImage()
-        catalog = params.testImage.detectDipoleSources()
+        catalog = params.testImage.detectDipoleSources(minBinSize=32)
 
         for s in catalog:
             fp = s.getFootprint()
@@ -135,7 +134,7 @@ class DipoleFitTest(lsst.utils.tests.TestCase):
 
         # Create the various tasks and schema -- avoid code reuse.
         testImage = params.testImage
-        detectTask, schema = testImage.detectDipoleSources(doMerge=False)
+        detectTask, schema = testImage.detectDipoleSources(doMerge=False, minBinSize=32)
 
         measureConfig = measBase.SingleFrameMeasurementConfig()
 


### PR DESCRIPTION
This includes setting the random seed explicitly in the test dataset
realization code and allowing for more configs to be specified in the
call to the detectDipoleSources() function in utils.py.  In particular,
the re-estimation of the background fails in test_dipoleFitter.py when
weighting is turned on, so wether to weight when approximating the
background is now controlled by an input parameter to the function (set
to True by default, but False for the test case here).

I also allowed for the default binSize for background estimation to be
adjusted as the current default of 128 is not appropriate for test
images typically on the order of 100x100 pixels.  To avoid decreasing
the binSize by too much, a minimum binSize input parameter is provided.