### PR TITLE
DM-3704: Refactor ImageDifferenceTask

### DIFF
--- a/python/lsst/ip/diffim/__init__.py
+++ b/python/lsst/ip/diffim/__init__.py
@@ -43,6 +43,10 @@ from .dipoleFitTask import *
 from .imageDecorrelation import *
 from .imageMapReduce import *
 from .zogy import *
+from .registerImage import *
+from .makeDiffim import *
+from .processDiffim import *
+from .imageDifference import *
 from .version import *
 
 # automatically register ip_diffim Algorithms

--- a/python/lsst/ip/diffim/imageDifference.py
+++ b/python/lsst/ip/diffim/imageDifference.py
@@ -1,0 +1,327 @@
+#
+# LSST Data Management System
+# Copyright 2012 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import absolute_import, division, print_function
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.daf.base as dafBase
+import lsst.afw.table as afwTable
+from . import MakeDiffimTask, ProcessDiffimTask, GetCoaddAsTemplateTask, \
+    KernelCandidateF, SourceFlagChecker, DipoleAnalysis
+from . import diffimTools
+from . import utils as diUtils
+
+
+class ImageDifferenceConfig(pexConfig.Config):
+    """Config for ImageDifferenceTask
+    """
+    doAddCalexpBackground = pexConfig.Field(dtype=bool, default=True,
+                                            doc="Add background to calexp before processing it.  "
+                                            "Useful as ipDiffim does background matching.")
+
+    doDetection = pexConfig.Field(dtype=bool, default=True, doc="Detect sources?")
+
+    coaddName = pexConfig.Field(
+        doc="coadd name: typically one of deep or goodSeeing",
+        dtype=str,
+        default="deep",
+    )
+
+    makeDiffim = pexConfig.ConfigurableField(
+        target=MakeDiffimTask,
+        doc="Perform image subtraction"
+    )
+
+    processDiffim = pexConfig.ConfigurableField(
+        target=ProcessDiffimTask,
+        doc="Process subtracted image: detect and measure DIASources"
+    )
+
+    getTemplate = pexConfig.ConfigurableField(
+        target=GetCoaddAsTemplateTask,
+        doc="Subtask to retrieve template exposure and sources",
+    )
+
+    def setDefaults(self):
+        # Add filtered flux measurement, the correct measurement for pre-convolved images.
+        # Enable all measurements, regardless of doPreConvolve, as it makes data harvesting easier.
+        # To change that you must modify algorithms.names in the task's applyOverrides method,
+        # after the user has set doPreConvolve.
+        self.processDiffim.measurement.algorithms.names.add('base_PeakLikelihoodFlux')
+
+    def validate(self):
+        pexConfig.Config.validate(self)
+        if self.processDiffim.doMeasurement and not self.doDetection:
+            raise ValueError("Cannot run source measurement without source detection.")
+        if self.processDiffim.doMerge and not self.doDetection:
+            raise ValueError("Cannot run source merging without source detection.")
+
+
+class ImageDifferenceTaskRunner(pipeBase.ButlerInitializedTaskRunner):
+
+    @staticmethod
+    def getTargetList(parsedCmd, **kwargs):
+        return pipeBase.TaskRunner.getTargetList(parsedCmd, templateIdList=parsedCmd.templateId.idList,
+                                                 **kwargs)
+
+
+class ImageDifferenceTask(pipeBase.CmdLineTask):
+    """Subtract an image from a template and measure the result
+    """
+    ConfigClass = ImageDifferenceConfig
+    RunnerClass = ImageDifferenceTaskRunner
+    _DefaultName = "imageDifference"
+
+    def __init__(self, butler=None, **kwargs):
+        """!Construct an ImageDifference Task
+
+        @param[in] butler  Butler object to use in constructing reference object loaders
+        """
+        pipeBase.CmdLineTask.__init__(self, **kwargs)
+        self.makeSubtask("getTemplate")
+
+        self.schema = afwTable.SourceTable.makeMinimalSchema()
+
+        self.makeSubtask("makeDiffim", butler=butler)
+        if self.config.doDetection:
+            self.makeSubtask("processDiffim", schema=self.schema)
+
+        self.algMetadata = dafBase.PropertyList()
+        self.makeDiffim.algMetadata = self.processDiffim.algMetadata = self.algMetadata
+
+        self.makeDiffim.doAddCalexpBackground = self.config.doAddCalexpBackground
+        if self.config.doDetection:
+            self.processDiffim.doAddCalexpBackground = self.config.doAddCalexpBackground
+
+    @pipeBase.timeMethod
+    def run(self, sensorRef, templateIdList=None):
+        """Subtract an image from a template coadd and measure the result
+
+        Steps include:
+        - warp template coadd to match WCS of image
+        - PSF match image to warped template
+        - subtract image from PSF-matched, warped template
+        - persist difference image
+        - detect sources
+        - measure sources
+
+        @param sensorRef: sensor-level butler data reference, used for the following data products:
+        Input only:
+        - calexp
+        - psf
+        - ccdExposureId
+        - ccdExposureId_bits
+        - self.config.coaddName + "Coadd_skyMap"
+        - self.config.coaddName + "Coadd"
+        Input or output, depending on config:
+        - self.config.coaddName + "Diff_subtractedExp"
+        Output, depending on config:
+        - self.config.coaddName + "Diff_matchedExp"
+        - self.config.coaddName + "Diff_src"
+
+        @return pipe_base Struct containing these fields:
+        - subtractedExposure: exposure after subtracting template;
+            the unpersisted version if subtraction not run but detection run
+            None if neither subtraction nor detection run (i.e. nothing useful done)
+        - subtractRes: results of subtraction task; None if subtraction not run
+        - sources: detected and possibly measured sources; None if detection not run
+        """
+        self.log.info("Processing %s" % (sensorRef.dataId))
+
+        # We make one IdFactory that will be used by both icSrc and src datasets;
+        # I don't know if this is the way we ultimately want to do things, but at least
+        # this ensures the source IDs are fully unique.
+        expBits = sensorRef.get("ccdExposureId_bits")
+        expId = int(sensorRef.get("ccdExposureId"))
+        idFactory = afwTable.IdFactory.makeSource(expId, 64 - expBits)
+
+        # Retrieve the science image we wish to analyze
+        exposure = sensorRef.get("calexp", immediate=True)
+        if self.config.doAddCalexpBackground:
+            mi = exposure.getMaskedImage()
+            mi += sensorRef.get("calexpBackground").getImage()
+        if not exposure.hasPsf():
+            raise pipeBase.TaskError("Exposure has no psf")
+
+        template = self.getTemplate.run(exposure, sensorRef, templateIdList=templateIdList)
+
+        mdResult = self.makeDiffim.doMakeDiffim(template, exposure,
+                                                idFactory=idFactory, sensorRef=sensorRef)
+        subtractedExposure = mdResult.subtractedExposure
+        # Zogy does not yet return a matched exposure
+        matchedExposure = mdResult.matchedExposure if 'matchedExposure' in mdResult.getDict() else None
+
+        selectSources = None
+        if 'selectSourceResult' in mdResult.getDict():
+            selectSourceResult = mdResult.selectSourceResult
+            selectSources = selectSourceResult.selectSources
+        pdResult = self.processDiffim.doProcessDiffim(subtractedExposure, exposure, matchedExposure,
+                                                      isPreConvolved=self.makeDiffim.config.doPreConvolve,
+                                                      isDecorrelated=self.makeDiffim.config.doDecorrelation,
+                                                      selectSources=selectSources,
+                                                      idFactory=idFactory, sensorRef=sensorRef)
+        diaSources = pdResult.sources
+
+        if (self.makeDiffim.config.doAddMetrics and self.makeDiffim.config.doSelectSources and
+                'selectSourceResult' in mdResult.getDict()):
+            selectSourceResult = mdResult.selectSourceResult
+            selectSources = selectSourceResult.selectSources
+            self.doEvaluateMetrics(mdResult, selectSourceResult.controlSources, selectSources,
+                                   diaSources, selectSourceResult.kcQa, selectSourceResult.nparam,
+                                   mdResult.allresids, exposure)
+            sensorRef.put(selectSources, self.config.coaddName + "Diff_kernelSrc")
+
+            kernelSources = selectSourceResult.kernelSources
+            self.runDebug(exposure, mdResult, selectSources, kernelSources, diaSources)
+
+        return pipeBase.Struct(
+            subtractedExposure=subtractedExposure,
+            subtractRes=mdResult,
+            sources=diaSources,
+        )
+
+    def doEvaluateMetrics(self, subtractRes, controlSources, selectSources, diaSources, kcQa,
+                          nparam, allresids, exposure):
+        self.log.info("Evaluating metrics and control sample")
+
+        kernelCandList = []
+        for cell in subtractRes.kernelCellSet.getCellList():
+            for cand in cell.begin(False):  # include bad candidates
+                kernelCandList.append(cand)
+
+        # Get basis list to build control sample kernels
+        basisList = kernelCandList[0].getKernel(KernelCandidateF.ORIG).getKernelList()
+
+        controlCandList = \
+            diffimTools.sourceTableToCandidateList(controlSources,
+                                                   subtractRes.warpedExposure, exposure,
+                                                   self.config.subtract.kernel.active,
+                                                   self.config.subtract.kernel.active.detectionConfig,
+                                                   self.log, doBuild=True, basisList=basisList)
+
+        kcQa.apply(kernelCandList, subtractRes.psfMatchingKernel, subtractRes.backgroundModel,
+                   dof=nparam)
+        kcQa.apply(controlCandList, subtractRes.psfMatchingKernel, subtractRes.backgroundModel)
+
+        if self.config.doDetection:
+            self.kcQa.aggregate(selectSources, self.metadata, allresids, diaSources)
+        else:
+            self.kcQa.aggregate(selectSources, self.metadata, allresids)
+
+    def runDebug(self, exposure, subtractRes, selectSources, kernelSources, diaSources):
+        """@todo Test and update for current debug display and slot names
+        """
+        import lsstDebug
+        display = lsstDebug.Info(__name__).display
+        showSubtracted = lsstDebug.Info(__name__).showSubtracted
+        showPixelResiduals = lsstDebug.Info(__name__).showPixelResiduals
+        showDiaSources = lsstDebug.Info(__name__).showDiaSources
+        showDipoles = lsstDebug.Info(__name__).showDipoles
+        maskTransparency = lsstDebug.Info(__name__).maskTransparency
+        if display:
+            import lsst.afw.display.ds9 as ds9
+            if not maskTransparency:
+                maskTransparency = 0
+            ds9.setMaskTransparency(maskTransparency)
+
+        if display and showSubtracted:
+            ds9.mtv(subtractRes.subtractedExposure, frame=lsstDebug.frame, title="Subtracted image")
+            mi = subtractRes.subtractedExposure.getMaskedImage()
+            x0, y0 = mi.getX0(), mi.getY0()
+            with ds9.Buffering():
+                for s in diaSources:
+                    x, y = s.getX() - x0, s.getY() - y0
+                    ctype = "red" if s.get("flags.negative") else "yellow"
+                    if (s.get("flags.pixel.interpolated.center") or s.get("flags.pixel.saturated.center") or
+                            s.get("flags.pixel.cr.center")):
+                        ptype = "x"
+                    elif (s.get("flags.pixel.interpolated.any") or s.get("flags.pixel.saturated.any") or
+                          s.get("flags.pixel.cr.any")):
+                        ptype = "+"
+                    else:
+                        ptype = "o"
+                    ds9.dot(ptype, x, y, size=4, frame=lsstDebug.frame, ctype=ctype)
+            lsstDebug.frame += 1
+
+        if display and showPixelResiduals and selectSources:
+            nonKernelSources = []
+            for source in selectSources:
+                if source not in kernelSources:
+                    nonKernelSources.append(source)
+
+            diUtils.plotPixelResiduals(exposure,
+                                       subtractRes.warpedExposure,
+                                       subtractRes.subtractedExposure,
+                                       subtractRes.kernelCellSet,
+                                       subtractRes.psfMatchingKernel,
+                                       subtractRes.backgroundModel,
+                                       nonKernelSources,
+                                       self.subtract.config.kernel.active.detectionConfig,
+                                       origVariance=False)
+            diUtils.plotPixelResiduals(exposure,
+                                       subtractRes.warpedExposure,
+                                       subtractRes.subtractedExposure,
+                                       subtractRes.kernelCellSet,
+                                       subtractRes.psfMatchingKernel,
+                                       subtractRes.backgroundModel,
+                                       nonKernelSources,
+                                       self.subtract.config.kernel.active.detectionConfig,
+                                       origVariance=True)
+        if display and showDiaSources:
+            flagChecker = SourceFlagChecker(diaSources)
+            isFlagged = [flagChecker(x) for x in diaSources]
+            isDipole = [x.get("classification.dipole") for x in diaSources]
+            diUtils.showDiaSources(diaSources, subtractRes.subtractedExposure, isFlagged, isDipole,
+                                   frame=lsstDebug.frame)
+            lsstDebug.frame += 1
+
+        if display and showDipoles:
+            DipoleAnalysis().displayDipoles(subtractRes.subtractedExposure, diaSources,
+                                            frame=lsstDebug.frame)
+            lsstDebug.frame += 1
+
+    def _getConfigName(self):
+        """Return the name of the config dataset
+        """
+        return "%sDiff_config" % (self.config.coaddName,)
+
+    def _getMetadataName(self):
+        """Return the name of the metadata dataset
+        """
+        return "%sDiff_metadata" % (self.config.coaddName,)
+
+    def getSchemaCatalogs(self):
+        """Return a dict of empty catalogs for each catalog dataset produced by this task."""
+        diaSrc = afwTable.SourceCatalog(self.schema)
+        diaSrc.getTable().setMetadata(self.algMetadata)
+        return {self.config.coaddName + "Diff_diaSrc": diaSrc}
+
+    @classmethod
+    def _makeArgumentParser(cls):
+        """Create an argument parser
+        """
+        parser = pipeBase.ArgumentParser(name=cls._DefaultName)
+        parser.add_id_argument("--id", "calexp", help="data ID, e.g. --id visit=12345 ccd=1,2")
+        parser.add_id_argument("--templateId", "calexp", doMakeDataRefList=True,
+                               help="Optional template data ID (visit only), e.g. --templateId visit=6789")
+        return parser
+

--- a/python/lsst/ip/diffim/imageDifference.py
+++ b/python/lsst/ip/diffim/imageDifference.py
@@ -62,10 +62,13 @@ class ImageDifferenceConfig(pexConfig.Config):
     )
 
     def setDefaults(self):
-        # Add filtered flux measurement, the correct measurement for pre-convolved images.
-        # Enable all measurements, regardless of doPreConvolve, as it makes data harvesting easier.
-        # To change that you must modify algorithms.names in the task's applyOverrides method,
-        # after the user has set doPreConvolve.
+        """Add PeakLikelihoodFlux measurement algorithm to default measurement list.
+        
+        If `doPreConvolve` is True, then the resulting diffim is already match-filtered.
+        In that case we want to use PeakLikelihoodFlux measurement on that image. Here, we
+        are just adding that measurement algorithm to the default list of measurements, whether
+        doPreConvolve is True or not. This makes sure the catalogs in either case are the same.
+        """
         self.processDiffim.measurement.algorithms.names.add('base_PeakLikelihoodFlux')
 
     def validate(self):
@@ -201,8 +204,7 @@ class ImageDifferenceTask(pipeBase.CmdLineTask):
 
     def doEvaluateMetrics(self, subtractRes, controlSources, selectSources, diaSources, kcQa,
                           nparam, allresids, exposure):
-        """
-        NEED A DOCSTRING
+        """Deprecated metric evaluation option ported from pipe_tasks
         """
         self.log.info("Evaluating metrics and control sample")
 
@@ -221,6 +223,8 @@ class ImageDifferenceTask(pipeBase.CmdLineTask):
             self.config.subtract.kernel.active.detectionConfig,
             self.log, doBuild=True, basisList=basisList)
 
+        # Evaluate the QA metrics for all KernelCandidates in the candidateList
+        # Set the values of the metrics in their associated Sources
         kcQa.apply(kernelCandList, subtractRes.psfMatchingKernel, subtractRes.backgroundModel,
                    dof=nparam)
         kcQa.apply(controlCandList, subtractRes.psfMatchingKernel, subtractRes.backgroundModel)

--- a/python/lsst/ip/diffim/makeDiffim.py
+++ b/python/lsst/ip/diffim/makeDiffim.py
@@ -1,0 +1,874 @@
+from __future__ import absolute_import, division, print_function
+#
+# LSST Data Management System
+# Copyright 2016 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from builtins import zip
+import math
+import random
+import numpy
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.daf.base as dafBase
+import lsst.afw.geom as afwGeom
+import lsst.afw.math as afwMath
+import lsst.afw.table as afwTable
+from lsst.meas.astrom import AstrometryTask
+from lsst.meas.extensions.astrometryNet import LoadAstrometryNetObjectsTask
+from lsst.meas.algorithms import SingleGaussianPsf, \
+    ObjectSizeStarSelectorTask
+from . import ImagePsfMatchTask, ZogyImagePsfMatchTask, makeKernelBasisList, \
+    KernelCandidateQa, DiaCatalogSourceSelectorTask, DiaCatalogSourceSelectorConfig, \
+    RegisterTask, GetCoaddAsTemplateTask, GetCalexpAsTemplateTask, \
+    DecorrelateALKernelSpatialTask, subtractAlgorithmRegistry
+
+__all__ = ["MakeDiffimTask", "MakeDiffimConfig"]
+
+FwhmPerSigma = 2 * math.sqrt(2 * math.log(2))
+IqrToSigma = 0.741
+
+
+class MakeDiffimConfig(pexConfig.Config):
+    """Config for MakeDiffimTask
+    """
+    doAddCalexpBackground = pexConfig.Field(
+        doc="Add background to calexp before processing it. Useful as ipDiffim does background matching.",
+        dtype=bool,
+        default=True
+    )
+
+    doUseRegister = pexConfig.Field(
+        doc="Use image-to-image registration to align template with science image",
+        dtype=bool,
+        default=True
+    )
+    doDebugRegister = pexConfig.Field(
+        doc="Writing debugging data for doUseRegister",
+        dtype=bool,
+        default=False
+    )
+    doSelectSources = pexConfig.Field(
+        doc="Select stars to use for kernel fitting",
+        dtype=bool,
+        default=True
+    )
+    doSelectDcrCatalog = pexConfig.Field(
+        doc="Select stars of extreme color as part of the control sample",
+        dtype=bool,
+        default=False
+    )
+    doSelectVariableCatalog = pexConfig.Field(
+        doc="Select stars that are variable to be part of the control sample",
+        dtype=bool,
+        default=False
+    )
+    doPreConvolve = pexConfig.Field(
+        doc="Convolve science image by its PSF before PSF-matching?",
+        dtype=bool,
+        default=True
+    )
+    useGaussianForPreConvolution = pexConfig.Field(
+        doc="Use a simple gaussian PSF model for pre-convolution "
+            "(else use fit PSF)? Ignored if doPreConvolve false.",
+        dtype=bool,
+        default=True
+    )
+    doDecorrelation = pexConfig.Field(
+        doc="Perform diffim decorrelation to undo pixel correlation due to A&L "
+        "kernel convolution? If True, also update the diffim PSF.",
+        dtype=bool,
+        default=False
+    )
+    doWriteSubtractedExp = pexConfig.Field(
+        doc="Write difference exposure?",
+        dtype=bool,
+        default=True
+    )
+    doWriteMatchedExp = pexConfig.Field(
+        doc="Write warped and PSF-matched template coadd exposure?",
+        dtype=bool,
+        default=False
+    )
+    doAddMetrics = pexConfig.Field(
+        doc="Add columns to the source table to hold analysis metrics?",
+        dtype=bool,
+        default=True
+    )
+    coaddName = pexConfig.Field(
+        doc="coadd name: typically one of deep or goodSeeing",
+        dtype=str,
+        default="deep",
+    )
+    convolveTemplate = pexConfig.Field(
+        doc="Which image gets convolved (default = template)",
+        dtype=bool,
+        default=True
+    )
+    doSpatiallyVarying = pexConfig.Field(
+        doc="If using Zogy or A&L decorrelation, perform these on a grid across the "
+        "image in order to allow for spatial variations",
+        dtype=bool,
+        default=False,
+    )
+    refObjLoader = pexConfig.ConfigurableField(
+        target=LoadAstrometryNetObjectsTask,
+        doc="reference object loader",
+    )
+    astrometer = pexConfig.ConfigurableField(
+        target=AstrometryTask,
+        doc="astrometry task; used to match sources to reference objects, but not to fit a WCS",
+    )
+    sourceSelector = pexConfig.ConfigurableField(
+        target=ObjectSizeStarSelectorTask,
+        doc="Source selection algorithm",
+    )
+    subtract = subtractAlgorithmRegistry.makeField(
+        "Subtraction Algorithm",
+        default="al"
+    )
+    decorrelate = pexConfig.ConfigurableField(
+        target=DecorrelateALKernelSpatialTask,
+        doc="Decorrelate effects of A&L kernel convolution on image difference, only if doSubtract is True. "
+        "If this option is enabled, then detection.thresholdValue should be set to 5.0 (rather than the "
+        "default of 5.5).",
+    )
+    getTemplate = pexConfig.ConfigurableField(
+        target=GetCoaddAsTemplateTask,
+        doc="Subtask to retrieve template exposure and sources",
+    )
+    controlStepSize = pexConfig.Field(
+        doc="What step size (every Nth one) to select a control sample from the kernelSources",
+        dtype=int,
+        default=5
+    )
+    controlRandomSeed = pexConfig.Field(
+        doc = "Random seed for shuffing the control sample",
+        dtype = int,
+        default = 10
+    )
+    register = pexConfig.ConfigurableField(
+        target=RegisterTask,
+        doc="Task to enable image-to-image image registration (warping)",
+    )
+    kernelSourcesFromRef = pexConfig.Field(
+        doc="Select sources to measure kernel from reference catalog if True, template if false",
+        dtype=bool,
+        default=False
+    )
+    templateSipOrder = pexConfig.Field(
+        doc="Sip Order for fitting the Template Wcs (default is too high, overfitting)",
+        dtype=int,
+        default=2,
+    )
+
+    def setDefaults(self):
+        # defaults are OK for catalog and diacatalog
+        self.subtract['al'].kernel.name = "AL"
+        self.subtract['al'].kernel.active.fitForBackground = True
+        self.subtract['al'].kernel.active.spatialKernelOrder = 1
+        self.subtract['al'].kernel.active.spatialBgOrder = 0
+        self.doPreConvolve = False
+        self.doAddMetrics = False
+        self.doUseRegister = False
+
+        # For shuffling the control sample
+        random.seed(self.controlRandomSeed)
+
+    def validate(self):
+        pexConfig.Config.validate(self)
+        if self.doUseRegister and not self.doSelectSources:
+            raise ValueError("doUseRegister=True and doSelectSources=False. " +
+                             "Cannot run RegisterTask without selecting sources.")
+
+
+class MakeDiffimTaskRunner(pipeBase.ButlerInitializedTaskRunner):
+
+    @staticmethod
+    def getTargetList(parsedCmd, **kwargs):
+        return pipeBase.TaskRunner.getTargetList(parsedCmd, templateIdList=parsedCmd.templateId.idList,
+                                                 **kwargs)
+
+
+## \addtogroup LSST_task_documentation
+## \{
+## \page MakeDiffimTask
+## \ref MakeDiffimTask_ "MakeDiffimTask"
+## \copybrief MakeDiffimTask
+## \}
+
+
+class MakeDiffimTask(pipeBase.CmdLineTask):
+    """!
+\anchor MakeDiffimTask_
+
+\brief Subtract an image from a template and save the results
+
+\section ip_diffim_makeDiffim_Contents Contents
+
+ - \ref ip_diffim_makeDiffim_Purpose
+ - \ref ip_diffim_makeDiffim_Initialize
+ - \ref ip_diffim_makeDiffim_IO
+ - \ref ip_diffim_makeDiffim_Config
+ - \ref ip_diffim_makeDiffim_Example
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_makeDiffim_Purpose   Description
+
+This task serves as a wrapper around algorithms which take as input a template
+(exposure or coadd) and a "new" or science image, register the two to the same
+astrometric reference, match their PSFs, and subtract the two, writing out the
+image difference as well as (optionally) intermediate products.
+
+The subtraction algorithms are provided by the `subtract` subtask, which is
+registered in the subtractAlgorithmRegistry. Currently the two available algorithms
+are Alard and Lupton (optionally decorrelated) and ZOGY. See the ImagePsfMatchTask and
+ZogyTask documentation for more information on those algorithms.
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_makeDiffim_Initialize    Task initialization
+
+\copydoc \_\_init\_\_
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_makeDiffim_IO        Invoking the Task
+
+This task may be invoked in two ways:
+
+1. its run() method which expects a Butler sensorRef for loading all relevant data
+(template, science image, and catalogs).
+2. the doMakeDiffim() method which is called from run() but may also be called separately
+and expects the matched template and new exposures, as well as the diffim exposure and
+parameters which specify how the diffim was created by \ref MakeDiffimTask_ .
+
+See each method's returned lsst.pipe.base.Struct for more details.
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_makeDiffim_Config       Configuration parameters
+
+See \ref MakeDiffimConfig
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_makeDiffim_Example   A complete example of using MakeDiffimTask
+
+This task is called from lsst.ip.diffim.imageDifference.ImageDifferenceTask.run(), which
+may be used as an example. This task itself may be invoked via the command line, for
+example (using a single DECam exposure as the template, assuming obs_decam has been set up):
+
+\code
+processDiffim.py decamRepo --output decamDiffimRepo --id visit=289820 ccdnum=11 \
+     --templateId visit=288976 --configfile makeDiffimConfig.py \
+     --config doDecorrelation=True --config doSpatiallyVarying=True
+\endcode
+
+This assumes the following makeDiffimConfig.py file is in your working directory:
+
+\code
+config.doWriteSubtractedExp=True
+config.doWriteMatchedExp=True
+config.doDecorrelation=True
+config.subtract='al'
+
+config.subtract['zogy'].zogyConfig.inImageSpace=False
+
+from lsst.ip.diffim.getTemplate import GetCalexpAsTemplateTask
+config.getTemplate.retarget(GetCalexpAsTemplateTask)
+\endcode
+
+While the above example config contains parameters for the Zogy algorithm,
+it is not utilized by the above example command-line call. It is provided as an
+example of how to configure the `subtract` subtask.
+
+We have enabled some minor display debugging in this script via the
+--debug option.  However, if you have an lsstDebug debug.py in your
+PYTHONPATH you will get additional debugging displays.
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+    """
+    ConfigClass = MakeDiffimConfig
+    RunnerClass = MakeDiffimTaskRunner
+    _DefaultName = "makeDiffim"
+
+    def __init__(self, butler=None, **kwargs):
+        """Construct a MakeDiffim Task
+
+        Parameters
+        ----------
+        butler : Butler object to use in constructing reference object loaders
+        """
+        pipeBase.CmdLineTask.__init__(self, **kwargs)
+        self.makeSubtask("getTemplate")
+
+        self.makeSubtask("subtract")
+
+        if self.config.subtract.name == 'al' and self.config.doDecorrelation:
+            self.makeSubtask("decorrelate")
+
+        if self.config.doUseRegister:
+            self.makeSubtask("register")
+        self.schema = afwTable.SourceTable.makeMinimalSchema()
+
+        if self.config.doSelectSources:
+            self.makeSubtask("sourceSelector", schema=self.schema)
+            self.makeSubtask('refObjLoader', butler=butler)
+            self.makeSubtask("astrometer", refObjLoader=self.refObjLoader)
+
+        self.algMetadata = dafBase.PropertyList()
+
+    @pipeBase.timeMethod
+    def run(self, sensorRef, templateIdList=None):
+        """Subtract an image from a template and save the results
+
+        Steps include:
+        - warp template coadd to match WCS of image
+        - PSF match image to warped template
+        - subtract image from PSF-matched, warped template
+        - persist difference image
+
+        Parameters
+        ----------
+        sensorRef : sensor-level butler data reference, used for the following data products:
+            Input only:
+            - calexp
+            - psf
+            - ccdExposureId
+            - ccdExposureId_bits
+            - self.config.coaddName + "Coadd_skyMap"
+            - self.config.coaddName + "Coadd"
+            Input or output, depending on config:
+            - self.config.coaddName + "Diff_differenceExp"
+            Output, depending on config:
+            - self.config.coaddName + "Diff_matchedExp"
+
+        Returns
+        -------
+        pipe_base Struct containing these fields:
+        - subtractedExposure: exposure after subtracting template;
+            the unpersisted version if subtraction not run but detection run
+            None if neither subtraction nor detection run (i.e. nothing useful done)
+        - subtractRes: results of subtraction task; None if subtraction not run
+        """
+        self.log.info("Processing %s" % (sensorRef.dataId))
+
+        # We make one IdFactory that will be used by both icSrc and src datasets;
+        # I don't know if this is the way we ultimately want to do things, but at least
+        # this ensures the source IDs are fully unique.
+        expBits = sensorRef.get("ccdExposureId_bits")
+        expId = int(sensorRef.get("ccdExposureId"))
+        idFactory = afwTable.IdFactory.makeSource(expId, 64 - expBits)
+
+        # Retrieve the science image we wish to analyze
+        exposure = sensorRef.get("calexp", immediate=True)
+        template = self.getTemplate.run(exposure, sensorRef, templateIdList=templateIdList)
+
+        result = self.doMakeDiffim(template, exposure, idFactory=idFactory,
+                                   sensorRef=sensorRef)
+
+        return result
+
+    @pipeBase.timeMethod
+    def doMakeDiffim(self, template, exposure, idFactory=None, sensorRef=None):
+        """Make the diffim.
+
+        Parameters
+        ----------
+        template : lsst.afw.image.Exposure
+            Template exposure
+        exposure : lsst.afw.image.Exposure
+            'Science', or new exposure
+        idFactory : lsst.afw.table.Factory
+             Factory for the generation of Source ids
+        sensorRef :
+             Sensor-level butler data reference, used for the following data products
+                Input only:
+                - calexp
+                - psf
+                - ccdExposureId
+                - ccdExposureId_bits
+                - self.config.coaddName + "Coadd_skyMap"
+                - self.config.coaddName + "Coadd"
+                Input or output, depending on config:
+                - self.config.coaddName + "Diff_differenceExp"
+                Output, depending on config:
+                - self.config.coaddName + "Diff_matchedExp"
+
+        Returns
+        -------
+        pipe_base Struct containing these fields:
+        - subtractedExposure: exposure after subtracting template;
+            the unpersisted version if subtraction not run but detection run
+            None if neither subtraction nor detection run (i.e. nothing useful done)
+        - subtractRes: results of subtraction task; None if subtraction not run
+
+        """
+        templateExposure = template.exposure   # Stitched coadd exposure
+        templateSources = template.sources    # Sources on the template image
+
+        if not exposure.hasPsf():
+            raise pipeBase.TaskError("Exposure has no psf")
+        sciencePsf = exposure.getPsf()
+
+        # compute scienceSigmaOrig: sigma of PSF of science image
+        scienceSigmaOrig = sciencePsf.computeShape().getDeterminantRadius()
+        self.scienceSigmaPost = scienceSigmaOrig
+        # compute scienceSigmaPost: sigma of PSF of science image after pre-convolution (A&L)
+        if self.config.doPreConvolve:
+            self.scienceSigmaPost = scienceSigmaOrig * math.sqrt(2)
+
+        # If requested, find sources in the image
+        selectSourceRes = None
+        selectSources = None
+        kernelSources = None
+        matches = None
+        if self.config.doSelectSources:
+            selectSourcesRes = self.runSelectSources(exposure, templateExposure,
+                                                     templateSources, idFactory, sensorRef=sensorRef)
+            selectSources = selectSourcesRes.selectSources
+            kernelSources = selectSourcesRes.kernelSources
+            matches = selectSourcesRes.matches
+
+        allresids = {}
+        if self.config.doUseRegister:
+            res = self.runRegister(exposure, templateExposure, templateSources,
+                                   selectSources, idFactory=None)
+            wcsResults = res.wcsResults
+            templateExposure = res.templateExposure
+            # Create debugging outputs on the astrometric
+            # residuals as a function of position.  Persistence
+            # not yet implemented; expected on (I believe) #2636.
+            if self.config.doDebugRegister:
+                allresids = self.runDebugRegister(wcsResults, matches)
+
+        if self.config.subtract.name == 'zogy':
+            subtractRes = self.subtract.subtractExposures(templateExposure, exposure,
+                                                          doWarping=True,
+                                                          spatiallyVarying=self.config.doSpatiallyVarying,
+                                                          doPreConvolve=self.config.doPreConvolve)
+            subtractedExposure = subtractRes.subtractedExposure
+
+        elif self.config.subtract.name == 'al':
+            # Useful since AL can match backgrounds (Zogy cannot)
+            if self.config.doAddCalexpBackground:
+                mi = exposure.getMaskedImage()
+                mi += sensorRef.get("calexpBackground").getImage()
+
+            # if requested, convolve the science exposure with its PSF
+            # (properly, this should be a cross-correlation, but our code does not yet support that)
+            preConvPsf = None
+            if self.config.doPreConvolve:
+                convControl = afwMath.ConvolutionControl()
+                # cannot convolve in place, so make a new MI to receive convolved image
+                srcMI = exposure.getMaskedImage()
+                destMI = srcMI.Factory(srcMI.getDimensions())
+                srcPsf = sciencePsf
+                if self.config.useGaussianForPreConvolution:
+                    # convolve with a simplified PSF model: a double Gaussian
+                    kWidth, kHeight = sciencePsf.getLocalKernel().getDimensions()
+                    preConvPsf = SingleGaussianPsf(kWidth, kHeight, scienceSigmaOrig)
+                else:
+                    # convolve with science exposure's PSF model
+                    preConvPsf = srcPsf
+                afwMath.convolve(destMI, srcMI, preConvPsf.getLocalKernel(), convControl)
+                exposure.setMaskedImage(destMI)
+
+            # warp template exposure to match exposure,
+            # PSF match template exposure to exposure,
+            # then return the difference
+
+            # Return warped template...
+            self.log.info("Subtracting images")
+            subtractRes = self.subtract.subtractExposures(
+                templateExposure=templateExposure,
+                scienceExposure=exposure,
+                candidateList=kernelSources,
+                convolveTemplate=self.config.convolveTemplate,
+                doWarping=not self.config.doUseRegister
+            )
+            subtractedExposure = subtractRes.subtractedExposure
+
+            # Add the selectSources result to the final result Struct.
+            if selectSourceRes is not None:
+                subtractRes.selectSourceResult = selectSourceRes
+            subtractRes.allresids = allresids
+
+            self.log.info("Computing diffim PSF")
+
+            # Get Psf from the appropriate input image if it doesn't exist
+            if not subtractedExposure.hasPsf():
+                if self.config.convolveTemplate:
+                    subtractedExposure.setPsf(exposure.getPsf())
+                else:
+                    subtractedExposure.setPsf(template.exposure.getPsf())
+
+            # Perform diffim decorrelation
+            if self.config.doDecorrelation:
+                preConvKernel = None
+                if preConvPsf is not None:
+                    preConvKernel = preConvPsf.getLocalKernel()
+                decorrResult = self.decorrelate.run(exposure, templateExposure,
+                                                    subtractedExposure,
+                                                    subtractRes.psfMatchingKernel,
+                                                    spatiallyVarying=self.config.doSpatiallyVarying,
+                                                    preConvKernel=preConvKernel)
+                subtractedExposure = decorrResult.correctedExposure
+                subtractRes.subtractedExposure = subtractedExposure
+
+        if sensorRef is not None:
+            if self.config.doWriteMatchedExp and 'matchedImage' in subtractRes.getDict():
+                self.log.info("Writing matched exposure, %s" %
+                              (self.config.coaddName + "Diff_matchedExp"))
+                sensorRef.put(subtractRes.matchedImage, self.config.coaddName + "Diff_matchedExp")
+
+            if self.config.doWriteSubtractedExp and 'subtractedExposure' in subtractRes.getDict():
+                self.log.info("Writing subtracted exposure, %s" %
+                              (self.config.coaddName + "Diff_differenceExp"))
+                subtractedExposureName = self.config.coaddName + "Diff_differenceExp"
+                sensorRef.put(subtractRes.subtractedExposure, subtractedExposureName)
+
+        return subtractRes
+
+    @staticmethod
+    def getSelectSources(exposure, isPreConvolved, log=None, idFactory=None, sensorRef=None):
+        """Load sources for exposure or detect them if not available.
+
+        Parameters
+        ----------
+        exposure : lsst.afw.image.Exposure
+            Exposure to detect on
+        isPreConvolved : bool
+            True if exposure was pre-convolved with its own PSF
+        log : lsst.log.Log
+            For logging info on how sources were detected or loaded
+        idFactory : lsst.afw.table.Factory
+             Factory for the generation of Source ids
+        sensorRef :
+             Sensor-level butler data reference, used for input science image src data product
+
+        Returns
+        -------
+        lsst.afw.table.SourceCatalog containing loaded or detected sources
+        """
+
+        if sensorRef is not None and sensorRef.datasetExists("src"):
+            if log is not None:
+                log.info("Source selection via src product")
+            selectSources = sensorRef.get("src")
+        else:
+            # Run own detection and measurement; necessary in nightly processing
+            if log is not None:
+                log.warn("Src product does not exist; running detection, measurement, selection")
+            # compute scienceSigma: sigma of PSF of science image after pre-convolution (A&L)
+            scienceSigma = exposure.getpsf().computeShape().getDeterminantRadius()
+            if isPreConvolved:
+                scienceSigma *= math.sqrt(2)
+            selectSources = self.subtract.getSelectSources(
+                exposure,
+                sigma=scienceSigma,
+                doSmooth=not isPreConvolved,
+                idFactory=idFactory,
+            )
+        return selectSources
+
+    def runSelectSources(self, exposure, templateExposure, templateSources,
+                         idFactory=None, sensorRef=None):
+        """Select sources for AL kernel fitting
+
+        Parameters
+        ----------
+        exposure : lsst.afw.image.Exposure
+            'Science', or new exposure
+        templateExposure : lsst.afw.image.Exposure
+            Template exposure
+        templateSources : lsst.afw.table.SourceCatalog
+            Sources detected in template
+        idFactory : lsst.afw.table.Factory
+             Factory for the generation of Source ids
+        sensorRef :
+             Sensor-level butler data reference, used for input science image src data product
+
+        Returns
+        -------
+        lsst.pipe.base.Struct containing the following elements:
+            selectSources: sourceCatalog containing sources to be used for registration
+            kernelSources: sourceCatalog containing sources to be used for PSF matching
+            controlSources: sourceCatalog containing control sources for PSF matching
+            matches: astrometric matches from astrometerTask
+            kcQa: KernelCandidateQa object
+            nparam: Number of kernel basis functions)
+        """
+        selectSources = MakeDiffimTask.getSelectSources(exposure, self.config.doPreConvolve,
+                                                        self.log, idFactory, sensorRef)
+        kcQa = nparam = None
+        if self.config.doAddMetrics:
+            # sigma of PSF of template image before warping
+            templateSigma = templateExposure.getPsf().computeShape().getDeterminantRadius()
+            # Number of basis functions
+            nparam = len(makeKernelBasisList(self.subtract.config.kernel.active,
+                                             referenceFwhmPix=self.scienceSigmaPost * FwhmPerSigma,
+                                             targetFwhmPix=templateSigma * FwhmPerSigma))
+            # Modify the schema of all Sources
+            kcQa = KernelCandidateQa(nparam)
+            selectSources = kcQa.addToSchema(selectSources)
+
+        if self.config.kernelSourcesFromRef:
+            # match exposure sources to reference catalog
+            astromRet = self.astrometer.loadAndMatch(exposure=exposure, sourceCat=selectSources)
+            matches = astromRet.matches
+        elif templateSources is not None:
+            # match exposure sources to template sources
+            mc = afwTable.MatchControl()
+            mc.findOnlyClosest = False
+            matches = afwTable.matchRaDec(templateSources, selectSources, 1.0*afwGeom.arcseconds,
+                                          mc)
+        else:
+            raise RuntimeError("doSelectSources=True and kernelSourcesFromRef=False," +
+                               "but template sources not available. Cannot match science " +
+                               "sources with template sources. Run process* on data from " +
+                               "which templates are built.")
+
+        kernelSources = self.sourceSelector.selectStars(exposure, selectSources,
+                                                        matches=matches).starCat
+
+        random.shuffle(kernelSources, random.random)
+        controlSources = kernelSources[::self.config.controlStepSize]
+        kernelSources = [k for i, k in enumerate(kernelSources) if i % self.config.controlStepSize]
+
+        if self.config.doSelectDcrCatalog:
+            redSelector = DiaCatalogSourceSelectorTask(
+                DiaCatalogSourceSelectorConfig(grMin=self.sourceSelector.config.grMax, grMax=99.999))
+            redSources = redSelector.selectStars(exposure, selectSources, matches=matches).starCat
+            controlSources.extend(redSources)
+
+            blueSelector = DiaCatalogSourceSelectorTask(
+                DiaCatalogSourceSelectorConfig(grMin=-99.999, grMax=self.sourceSelector.config.grMin))
+            blueSources = blueSelector.selectStars(exposure, selectSources, matches=matches).starCat
+            controlSources.extend(blueSources)
+
+        if self.config.doSelectVariableCatalog:
+            varSelector = DiaCatalogSourceSelectorTask(
+                DiaCatalogSourceSelectorConfig(includeVariable=True))
+            varSources = varSelector.selectStars(exposure, selectSources, matches=matches).starCat
+            controlSources.extend(varSources)
+
+        self.log.info("Selected %d / %d sources for Psf matching (%d for control sample)"
+                      % (len(kernelSources), len(selectSources), len(controlSources)))
+
+        return pipeBase.Struct(selectSources=selectSources,
+                               kernelSources=kernelSources,
+                               controlSources=controlSources,
+                               matches=matches,
+                               kcQa=kcQa, nparam=nparam)
+
+    def runRegister(self, exposure, templateExposure, templateSources, selectSources, idFactory=None):
+        """Perform image-to-image registration to align template with science image
+
+        Parameters
+        ----------
+        exposure : lsst.afw.image.Exposure
+            'Science', or new exposure
+        templateExposure : lsst.afw.image.Exposure
+            Template exposure
+        templateSources : lsst.afw.table.SourceCatalog
+            Sources detected in template
+        selectSources : lsst.afw.table.SourceCatalog
+            Sources in science image
+        idFactory : lsst.afw.table.Factory
+             Factory for the generation of Source ids.
+        """
+        self.log.info("Registering images")
+
+        if templateSources is None:
+            # sigma of PSF of template image before warping
+            templateSigma = templateExposure.getPsf().computeShape().getDeterminantRadius()
+            # Run detection on the template, which is
+            # temporarily background-subtracted
+            templateSources = self.subtract.getSelectSources(
+                templateExposure,
+                sigma=templateSigma,
+                doSmooth=True,
+                idFactory=idFactory
+            )
+
+        # Third step: we need to fit the relative astrometry.
+        wcsResults = self.fitAstrometry(templateSources, templateExposure, selectSources)
+        warpedExp = self.register.warpExposure(templateExposure, wcsResults.wcs,
+                                               exposure.getWcs(), exposure.getBBox())
+        # Psf seems to get removed by the registration, so re-add it.
+        templPsf = templateExposure.getPsf()
+        templateExposure = warpedExp
+        templateExposure.setPsf(templPsf)
+        return pipeBase.Struct(wcsResults=wcsResults,
+                               templateExposure=templateExposure)
+
+    def runDebugRegister(self, wcsResults, matches):
+        """Create debugging outputs
+
+        Create debugging outputs on the astrometric
+        residuals as a function of position.  Persistence
+        not yet implemented; expected on (I believe) #2636.
+        """
+
+        # Grab matches to reference catalog
+        srcToMatch = {x.second.getId(): x.first for x in matches}
+
+        refCoordKey = wcsResults.matches[0].first.getTable().getCoordKey()
+        inCentroidKey = wcsResults.matches[0].second.getTable().getCentroidKey()
+        sids = [m.first.getId() for m in wcsResults.matches]
+        positions = [m.first.get(refCoordKey) for m in wcsResults.matches]
+        residuals = [m.first.get(refCoordKey).getOffsetFrom(wcsResults.wcs.pixelToSky(
+            m.second.get(inCentroidKey))) for m in wcsResults.matches]
+        allresids = dict(zip(sids, zip(positions, residuals)))
+
+        cresiduals = [m.first.get(refCoordKey).getTangentPlaneOffset(
+            wcsResults.wcs.pixelToSky(
+                m.second.get(inCentroidKey))) for m in wcsResults.matches]
+        colors = numpy.array([-2.5*numpy.log10(srcToMatch[x].get("g")) +
+                              2.5*numpy.log10(srcToMatch[x].get("r"))
+                              for x in sids if x in srcToMatch.keys()])
+        dlong = numpy.array([r[0].asArcseconds() for s, r in zip(sids, cresiduals)
+                             if s in srcToMatch.keys()])
+        dlat = numpy.array([r[1].asArcseconds() for s, r in zip(sids, cresiduals)
+                            if s in srcToMatch.keys()])
+        idx1 = numpy.where(colors < self.sourceSelector.config.grMin)
+        idx2 = numpy.where((colors >= self.sourceSelector.config.grMin) &
+                           (colors <= self.sourceSelector.config.grMax))
+        idx3 = numpy.where(colors > self.sourceSelector.config.grMax)
+        rms1Long = IqrToSigma * \
+            (numpy.percentile(dlong[idx1], 75)-numpy.percentile(dlong[idx1], 25))
+        rms1Lat = IqrToSigma*(numpy.percentile(dlat[idx1], 75)-numpy.percentile(dlat[idx1], 25))
+        rms2Long = IqrToSigma * \
+            (numpy.percentile(dlong[idx2], 75)-numpy.percentile(dlong[idx2], 25))
+        rms2Lat = IqrToSigma*(numpy.percentile(dlat[idx2], 75)-numpy.percentile(dlat[idx2], 25))
+        rms3Long = IqrToSigma * \
+            (numpy.percentile(dlong[idx3], 75)-numpy.percentile(dlong[idx3], 25))
+        rms3Lat = IqrToSigma*(numpy.percentile(dlat[idx3], 75)-numpy.percentile(dlat[idx3], 25))
+        self.log.info("Blue star offsets'': %.3f %.3f, %.3f %.3f" % (numpy.median(dlong[idx1]),
+                                                                     rms1Long,
+                                                                     numpy.median(dlat[idx1]),
+                                                                     rms1Lat))
+        self.log.info("Green star offsets'': %.3f %.3f, %.3f %.3f" % (numpy.median(dlong[idx2]),
+                                                                      rms2Long,
+                                                                      numpy.median(dlat[idx2]),
+                                                                      rms2Lat))
+        self.log.info("Red star offsets'': %.3f %.3f, %.3f %.3f" % (numpy.median(dlong[idx3]),
+                                                                    rms3Long,
+                                                                    numpy.median(dlat[idx3]),
+                                                                    rms3Lat))
+
+        self.metadata.add("RegisterBlueLongOffsetMedian", numpy.median(dlong[idx1]))
+        self.metadata.add("RegisterGreenLongOffsetMedian", numpy.median(dlong[idx2]))
+        self.metadata.add("RegisterRedLongOffsetMedian", numpy.median(dlong[idx3]))
+        self.metadata.add("RegisterBlueLongOffsetStd", rms1Long)
+        self.metadata.add("RegisterGreenLongOffsetStd", rms2Long)
+        self.metadata.add("RegisterRedLongOffsetStd", rms3Long)
+
+        self.metadata.add("RegisterBlueLatOffsetMedian", numpy.median(dlat[idx1]))
+        self.metadata.add("RegisterGreenLatOffsetMedian", numpy.median(dlat[idx2]))
+        self.metadata.add("RegisterRedLatOffsetMedian", numpy.median(dlat[idx3]))
+        self.metadata.add("RegisterBlueLatOffsetStd", rms1Lat)
+        self.metadata.add("RegisterGreenLatOffsetStd", rms2Lat)
+        self.metadata.add("RegisterRedLatOffsetStd", rms3Lat)
+        return allresids
+
+    def fitAstrometry(self, templateSources, templateExposure, selectSources):
+        """Fit the relative astrometry between templateSources and selectSources
+
+        Todo
+        ----
+        Remove this method. It originally fit a new WCS to the template before
+        calling register.run because our TAN-SIP fitter behaved badly
+        for points far from CRPIX, but that's been fixed.  It remains
+        because a subtask overrides it.
+        """
+        results = self.register.run(templateSources, templateExposure.getWcs(),
+                                    templateExposure.getBBox(), selectSources)
+        return results
+
+    def _getConfigName(self):
+        """Return the name of the config dataset
+        """
+        return "%sDiff_config" % (self.config.coaddName,)
+
+    def _getMetadataName(self):
+        """Return the name of the metadata dataset
+        """
+        return "%sDiff_metadata" % (self.config.coaddName,)
+
+    @classmethod
+    def _makeArgumentParser(cls):
+        """Create an argument parser
+        """
+        parser = pipeBase.ArgumentParser(name=cls._DefaultName)
+        parser.add_id_argument("--id", "calexp", help="data ID, e.g. --id visit=12345 ccd=1,2")
+        parser.add_id_argument("--templateId", "calexp", doMakeDataRefList=True,
+                               help="Optional template data ID (visit only), e.g. --templateId visit=6789")
+        return parser
+
+
+class Winter2013MakeDiffimConfig(MakeDiffimConfig):
+    winter2013WcsShift = pexConfig.Field(dtype=float, default=0.0,
+                                         doc="Shift stars going into RegisterTask by this amount")
+    winter2013WcsRms = pexConfig.Field(dtype=float, default=0.0,
+                                       doc="Perturb stars going into RegisterTask by this amount")
+
+    def setDefaults(self):
+        MakeDiffimConfig.setDefaults(self)
+        self.getTemplate.retarget(GetCalexpAsTemplateTask)
+
+
+class Winter2013MakeDiffimTask(MakeDiffimTask):
+    """Image difference Task used in the Winter 2013 data challege.
+    Enables testing the effects of registration shifts and scatter.
+
+    For use with winter 2013 simulated images:
+    Use --templateId visit=88868666 for sparse data
+        --templateId visit=22222200 for dense data (g)
+        --templateId visit=11111100 for dense data (i)
+    """
+    ConfigClass = Winter2013MakeDiffimConfig
+    _DefaultName = "winter2013MakeDiffim"
+
+    def __init__(self, **kwargs):
+        MakeDiffimTask.__init__(self, **kwargs)
+
+    def fitAstrometry(self, templateSources, templateExposure, selectSources):
+        """Fit the relative astrometry between templateSources and selectSources"""
+        if self.config.winter2013WcsShift > 0.0:
+            offset = afwGeom.Extent2D(self.config.winter2013WcsShift,
+                                      self.config.winter2013WcsShift)
+            cKey = templateSources[0].getTable().getCentroidKey()
+            for source in templateSources:
+                centroid = source.get(cKey)
+                source.set(cKey, centroid+offset)
+        elif self.config.winter2013WcsRms > 0.0:
+            cKey = templateSources[0].getTable().getCentroidKey()
+            for source in templateSources:
+                offset = afwGeom.Extent2D(self.config.winter2013WcsRms*numpy.random.normal(),
+                                          self.config.winter2013WcsRms*numpy.random.normal())
+                centroid = source.get(cKey)
+                source.set(cKey, centroid+offset)
+
+        results = self.register.run(templateSources, templateExposure.getWcs(),
+                                    templateExposure.getBBox(), selectSources)
+        return results

--- a/python/lsst/ip/diffim/makeDiffim.py
+++ b/python/lsst/ip/diffim/makeDiffim.py
@@ -140,8 +140,8 @@ class MakeDiffimConfig(pexConfig.Config):
         target=ObjectSizeStarSelectorTask,
         doc="Source selection algorithm",
     )
-    subtract = subtractAlgorithmRegistry.makeField(
-        "Subtraction Algorithm",
+    subtractAlgorithm = subtractAlgorithmRegistry.makeField(
+        doc="Which subtraction algorithm will be used",
         default="al"
     )
     decorrelate = pexConfig.ConfigurableField(
@@ -181,10 +181,10 @@ class MakeDiffimConfig(pexConfig.Config):
 
     def setDefaults(self):
         # defaults are OK for catalog and diacatalog
-        self.subtract['al'].kernel.name = "AL"
-        self.subtract['al'].kernel.active.fitForBackground = True
-        self.subtract['al'].kernel.active.spatialKernelOrder = 1
-        self.subtract['al'].kernel.active.spatialBgOrder = 0
+        self.subtractAlgorithm['al'].kernel.name = "AL"
+        self.subtractAlgorithm['al'].kernel.active.fitForBackground = True
+        self.subtractAlgorithm['al'].kernel.active.spatialKernelOrder = 1
+        self.subtractAlgorithm['al'].kernel.active.spatialBgOrder = 0
         self.doPreConvolve = False
         self.doAddMetrics = False
         self.doUseRegister = False
@@ -289,9 +289,9 @@ This assumes the following makeDiffimConfig.py file is in your working directory
 config.doWriteSubtractedExp=True
 config.doWriteMatchedExp=True
 config.doDecorrelation=True
-config.subtract='al'
+config.subtractAlgorithm='al'
 
-config.subtract['zogy'].zogyConfig.inImageSpace=False
+config.subtractAlgorithm['zogy'].zogyConfig.inImageSpace=False
 
 from lsst.ip.diffim.getTemplate import GetCalexpAsTemplateTask
 config.getTemplate.retarget(GetCalexpAsTemplateTask)
@@ -322,7 +322,7 @@ PYTHONPATH you will get additional debugging displays.
 
         self.makeSubtask("subtract")
 
-        if self.config.subtract.name == 'al' and self.config.doDecorrelation:
+        if self.config.subtractAlgorithm.name == 'al' and self.config.doDecorrelation:
             self.makeSubtask("decorrelate")
 
         if self.config.doUseRegister:
@@ -460,14 +460,14 @@ PYTHONPATH you will get additional debugging displays.
             if self.config.doDebugRegister:
                 allresids = self.runDebugRegister(wcsResults, matches)
 
-        if self.config.subtract.name == 'zogy':
+        if self.config.subtractAlgorithm.name == 'zogy':
             subtractRes = self.subtract.subtractExposures(templateExposure, exposure,
                                                           doWarping=True,
                                                           spatiallyVarying=self.config.doSpatiallyVarying,
                                                           doPreConvolve=self.config.doPreConvolve)
             subtractedExposure = subtractRes.subtractedExposure
 
-        elif self.config.subtract.name == 'al':
+        elif self.config.subtractAlgorithm.name == 'al':
             # Useful since AL can match backgrounds (Zogy cannot)
             if self.config.doAddCalexpBackground:
                 mi = exposure.getMaskedImage()

--- a/python/lsst/ip/diffim/processDiffim.py
+++ b/python/lsst/ip/diffim/processDiffim.py
@@ -1,0 +1,464 @@
+from __future__ import absolute_import, division, print_function
+#
+# LSST Data Management System
+# Copyright 2016 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+import random
+import math
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import lsst.daf.base as dafBase
+import lsst.afw.table as afwTable
+from lsst.meas.extensions.astrometryNet import LoadAstrometryNetObjectsTask
+from lsst.meas.astrom import AstrometryTask
+from lsst.meas.algorithms import SourceDetectionTask, LoadIndexedReferenceObjectsTask
+from . import MakeDiffimTask, GetCoaddAsTemplateTask, DipoleFitTask
+
+__all__ = ["ProcessDiffimTask", "ProcessDiffimConfig"]
+
+
+class ProcessDiffimConfig(pexConfig.Config):
+    """Config for ProcessDiffimTask
+    """
+    doAddCalexpBackground = pexConfig.Field(dtype=bool, default=True,
+                                            doc="Add background to calexp before processing it.  "
+                                                "Useful as ipDiffim does background matching.")
+    doMerge = pexConfig.Field(dtype=bool, default=True,
+                              doc="Merge positive and negative diaSources with grow radius "
+                                  "set by growFootprint")
+    doMatchSources = pexConfig.Field(dtype=bool, default=True,
+                                     doc="Match diaSources with input calexp sources and ref catalog sources")
+    doMeasurement = pexConfig.Field(dtype=bool, default=True, doc="Measure diaSources?")
+    doDipoleFitting = pexConfig.Field(dtype=bool, default=True, doc="Measure dipoles using new algorithm?")
+    doWriteSources = pexConfig.Field(dtype=bool, default=True, doc="Write sources?")
+
+    coaddName = pexConfig.Field(
+        doc="coadd name: typically one of deep or goodSeeing",
+        dtype=str,
+        default="deep",
+    )
+    detection = pexConfig.ConfigurableField(
+        target=SourceDetectionTask,
+        doc="Low-threshold detection for final measurement",
+    )
+    measurement = pexConfig.ConfigurableField(
+        target=DipoleFitTask,
+        doc="Enable updated dipole fitting method",
+    )
+    refObjLoader = pexConfig.ConfigurableField(
+        target=LoadAstrometryNetObjectsTask,
+        doc="reference object loader",
+    )
+    astrometer = pexConfig.ConfigurableField(
+        target=AstrometryTask,
+        doc="astrometry task; used to match sources to reference objects, but not to fit a WCS",
+    )
+    controlRandomSeed = pexConfig.Field(
+        doc = "Random seed for shuffing the control sample",
+        dtype = int,
+        default = 10
+    )
+
+    growFootprint = pexConfig.Field(
+        doc="Grow positive and negative footprints by this amount before merging",
+        dtype=int,
+        default=2
+    )
+
+    diaSourceMatchRadius = pexConfig.Field(
+        doc="Match radius (in arcseconds) for DiaSource to Source association",
+        dtype=float,
+        default=0.5
+    )
+    isPreConvolved = pexConfig.Field(
+        doc="Diffim is pre-convolved (doPreConvolve=True in makeDiffim)",
+        dtype=bool,
+        default=False
+    )
+    isDecorrelated = pexConfig.Field(
+        doc="Diffim is decorrelated (doDecorrelation=True in makeDiffim",
+        dtype=bool,
+        default=True
+    )
+
+    def setDefaults(self):
+        # defaults are OK for catalog and diacatalog
+        self.doMatchSources = False
+
+        # DiaSource Detection
+        self.detection.thresholdPolarity = "both"
+        self.detection.thresholdValue = 5.5
+        self.detection.reEstimateBackground = False
+        self.detection.thresholdType = "pixel_stdev"
+
+        # Add filtered flux measurement, the correct measurement for pre-convolved images.
+        # Enable all measurements, regardless of doPreConvolved, as it makes data harvesting easier.
+        # To change that you must modify algorithms.names in the task's applyOverrides method,
+        # after the user has set doPreConvolved.
+        self.measurement.algorithms.names.add('base_PeakLikelihoodFlux')
+
+        # For shuffling the control sample
+        random.seed(self.controlRandomSeed)
+
+    def validate(self):
+        pexConfig.Config.validate(self)
+
+
+class ProcessDiffimTaskRunner(pipeBase.ButlerInitializedTaskRunner):
+
+    @staticmethod
+    def getTargetList(parsedCmd, **kwargs):
+        return pipeBase.TaskRunner.getTargetList(parsedCmd, **kwargs)
+
+## \addtogroup LSST_task_documentation
+## \{
+## \page ProcessDiffimTask
+## \ref ProcessDiffimTask_ "ProcessDiffimTask"
+## \copybrief ProcessDiffimTask
+## \}
+
+
+class ProcessDiffimTask(pipeBase.CmdLineTask):
+    """!
+\anchor ProcessDiffimTask_
+
+\brief Subtract an image from a template and save the results
+
+\section ip_diffim_processDiffim_Contents Contents
+
+ - \ref ip_diffim_processDiffim_Purpose
+ - \ref ip_diffim_processDiffim_Initialize
+ - \ref ip_diffim_processDiffim_IO
+ - \ref ip_diffim_processDiffim_Config
+ - \ref ip_diffim_processDiffim_Example
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_processDiffim_Purpose   Description
+
+This task serves to process the image difference (diffim) produced by the
+lsst.ip.diffim.makeDiffim.MakeDiffimTask. This includes detection and measurement
+of sources in the diffim, and optionally saving the resulting catalog to disk.
+
+The detection and measurement algorithms are provided by the `detection` and `measurement`
+subtasks, respectively.
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_processDiffim_Initialize    Task initialization
+
+\copydoc \_\_init\_\_
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_processDiffim_IO        Invoking the Task
+
+This task may be invoked in two ways:
+
+1. its run() method which expects a Butler sensorRef for loading all relevant data
+(template, science image, and diffim).
+2. the doProcessDiffim() method which is called from run() but may also be called separately
+and expects the template and new exposures and optionally an idFactory and sensorRef for
+loading additional data.
+
+See each method's returned lsst.pipe.base.Struct for more details.
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_processDiffim_Config       Configuration parameters
+
+See \ref ProcessDiffimConfig
+
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+\section ip_diffim_processDiffim_Example   A complete example of using ProcessDiffimTask
+
+This task is called from lsst.ip.diffim.imageDifference.ImageDifferenceTask.run(), which
+may be used as an example. This task itself may be invoked via the command line, for
+example (assuming obs_decam has been set up and decamDiffimRepo was passed to
+makeDiffim.py as the output repo):
+
+\code
+processDiffim.py decamDiffimRepo --output decamDiaSrcRepo --id visit=289820 ccdnum=11
+\endcode
+
+This will add a new diaSrc record in the decamDiaSrcRepo.
+#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+    """
+    ConfigClass = ProcessDiffimConfig
+    RunnerClass = ProcessDiffimTaskRunner
+    _DefaultName = "processDiffim"
+
+    def __init__(self, schema=None, butler=None, **kwargs):
+        """Construct a ProcessDiffim Task
+
+        Parameters
+        ----------
+        butler : Butler object to use in constructing reference object loaders
+        """
+        pipeBase.CmdLineTask.__init__(self, **kwargs)
+
+        self.schema = schema
+        if schema is None:
+            self.schema = afwTable.SourceTable.makeMinimalSchema()
+
+        self.algMetadata = dafBase.PropertyList()
+        self.makeSubtask("detection", schema=self.schema)
+        if self.config.doMeasurement:
+            self.makeSubtask("measurement", schema=self.schema,
+                             algMetadata=self.algMetadata)
+        if self.config.doMatchSources:
+            self.makeSubtask('refObjLoader', butler=butler)
+            self.makeSubtask("astrometer", refObjLoader=self.refObjLoader)
+            self.schema.addField("refMatchId", "L", "unique id of reference catalog match")
+            self.schema.addField("srcMatchId", "L", "unique id of source match")
+
+    @pipeBase.timeMethod
+    def run(self, sensorRef):
+        """Measure the result of an image subtraction by calling doProcessDiffim
+
+        Parameters
+        ----------
+        sensorRef : sensor-level butler data reference, used for the following data products:
+            Input only:
+            - calexp
+            - psf
+            - ccdExposureId
+            - ccdExposureId_bits
+            - self.config.coaddName + "Coadd_skyMap"
+            - self.config.coaddName + "Coadd"
+            - self.config.coaddName + "Diff_differenceExp"
+            - self.config.coaddName + "Diff_matchedExp"
+            Output, depending on config:
+            - self.config.coaddName + "Diff_src"
+
+        Returns
+        -------
+        pipe_base Struct containing these fields:
+            - sources: detected and possibly measured sources
+        """
+        self.log.info("Processing %s" % (sensorRef.dataId))
+
+        # We make one IdFactory that will be used by both icSrc and src datasets;
+        # I don't know if this is the way we ultimately want to do things, but at least
+        # this ensures the source IDs are fully unique.
+        expBits = sensorRef.get("ccdExposureId_bits")
+        expId = int(sensorRef.get("ccdExposureId"))
+        idFactory = afwTable.IdFactory.makeSource(expId, 64 - expBits)
+
+        # Retrieve the science image we wish to analyze
+        exposure = sensorRef.get("calexp", immediate=True)
+        if self.config.doAddCalexpBackground:
+            mi = exposure.getMaskedImage()
+            mi += sensorRef.get("calexpBackground").getImage()
+        if not exposure.hasPsf():
+            raise pipeBase.TaskError("Exposure has no psf")
+
+        # Get the subtracted and matched exposures, and `selectSources` for metrics evaluation
+        subtractedExposure = sensorRef.get(self.config.coaddName + "Diff_differenceExp")
+        matchedExposure = sensorRef.get(self.config.coaddName + "Diff_matchedExp")
+
+        result = self.doProcessDiffim(subtractedExposure, exposure, matchedExposure,
+                                      isPreConvolved=self.config.isPreConvolved,
+                                      isDecorrelated=self.config.isDecorrelated,
+                                      selectSources=None, idFactory=idFactory,
+                                      sensorRef=sensorRef)
+
+        return result
+
+    @pipeBase.timeMethod
+    def doProcessDiffim(self, subtractedExposure, scienceExposure, matchedTemplateExposure,
+                        isPreConvolved=False, isDecorrelated=True, selectSources=None,
+                        idFactory=None, sensorRef=None):
+        """Measure the result of an image subtraction
+
+        Steps include:
+        - detect sources
+        - measure sources
+
+        Parameters
+        ----------
+        subtractedExposure : lsst.afw.image.Exposure
+            Subtracted exposure
+        scienceExposure : lsst.afw.image.Exposure
+            'Science', or new exposure
+        templateExposure : lsst.afw.image.Exposure
+            Template exposure
+        isPreConvolved : bool
+            Was the subtractedExposure pre-convolved? (see `makeDiffim.MakeDiffimConfig`)
+            This is used to select the type of detection and measurement performed
+        isDecorrelated : bool
+            Was the subtracted exposure decorrelated? (see `makeDiffim.MakeDiffimConfig`)
+            This is used to select the type of dipole measurement performed
+        selectSources : lsst.afw.table.SourceCatalog
+            Source catalog detected on scienceExposure and selected for A&L PSF
+            matching (see `makeDiffim.MakeDiffimTask`). If None, it is read from the
+            butler.
+        idFactory : lsst.afw.table.Factory
+             Factory for the generation of Source ids
+        sensorRef :
+             Sensor-level butler data reference, used for the following data products:
+                Input only:
+                - calexp
+                - psf
+                - ccdExposureId
+                - ccdExposureId_bits
+                - self.config.coaddName + "Coadd_skyMap"
+                - self.config.coaddName + "Coadd"
+                Input or output, depending on config:
+                - self.config.coaddName + "Diff_differenceExp"
+                Output, depending on config:
+                - self.config.coaddName + "Diff_matchedExp"
+
+        Returns
+        -------
+        pipe_base Struct containing these fields:
+            - sources: detected and possibly measured sources
+        """
+        self.log.info("Running diaSource detection")
+        # Erase existing detection mask planes
+        mask = subtractedExposure.getMaskedImage().getMask()
+        mask &= ~(mask.getPlaneBitMask("DETECTED") | mask.getPlaneBitMask("DETECTED_NEGATIVE"))
+
+        table = afwTable.SourceTable.make(self.schema, idFactory)
+        table.setMetadata(self.algMetadata)
+        results = self.detection.makeSourceCatalog(
+            table=table,
+            exposure=subtractedExposure,
+            doSmooth=not isPreConvolved,
+        )
+
+        if self.config.doMerge:
+            fpSet = results.fpSets.positive
+            fpSet.merge(results.fpSets.negative, self.config.growFootprint,
+                        self.config.growFootprint, False)
+            diaSources = afwTable.SourceCatalog(table)
+            fpSet.makeSources(diaSources)
+            self.log.info("Merging detections into %d sources" % (len(diaSources)))
+        else:
+            diaSources = results.sources
+
+        if self.config.doMeasurement:
+            newDipoleFitting = self.config.doDipoleFitting
+            self.log.info("Running diaSource measurement: newDipoleFitting=%r", newDipoleFitting)
+            if not newDipoleFitting:
+                # Just fit dipole in diffim
+                self.measurement.run(diaSources, subtractedExposure)
+            else:
+                # Use science image (if avail.) to constrain dipole fitting; matchedTemplate is
+                # computed in measurement.run() from scienceExposure - subtractedExposure.
+                if matchedTemplateExposure is not None and not isDecorrelated:
+                    self.measurement.run(diaSources, subtractedExposure, scienceExposure,
+                                         matchedTemplateExposure)
+                else:
+                    # If decorrelation is turned on, we don't want to use the matchedTemplate, since it
+                    # is not decorrelated. If we don't pass the matchedTemplate, then the dipoleFitter
+                    # automatically creates from scienceExposure - subtractedExposure.
+                    self.measurement.run(diaSources, subtractedExposure, scienceExposure)
+
+        if self.config.doMatchSources and sensorRef is not None:
+            # Match with the calexp sources if possible
+            selectSources = MakeDiffimTask.getSelectSources(scienceExposure, self.config.isPreConvolved,
+                                                            self.log, idFactory, sensorRef)
+            refObjLoader = LoadIndexedReferenceObjectsTask(butler=sensorRef.getButler())
+            diaSources = self.runMatchSources(diaSources, selectSources, scienceExposure,
+                                              refObjLoader)
+
+        if self.config.doWriteSources and diaSources is not None and sensorRef is not None:
+            self.log.info("Writing diaSources, %s" %
+                          (self.config.coaddName + "Diff_diaSrc"))
+            sensorRef.put(diaSources, self.config.coaddName + "Diff_diaSrc")
+
+        return pipeBase.Struct(
+            sources=diaSources
+        )
+
+    def runMatchSources(self, diaSources, selectSources, exposure, refObjLoader):
+        """Match diaSources and selectSources catalogs by RA/Dec
+
+        Parameters
+        ----------
+        diaSources : lsst.afw.table.SourceCatalog
+           Catalog of sources detected on diffim
+        selectSources : lsst.afw.table.SourceCatalog
+           Catalog of sources detected on science image and used for PSF matching
+
+        """
+        matchRadAsec = self.config.diaSourceMatchRadius
+        if selectSources is not None:
+            # Create key,val pair where key=diaSourceId and val=sourceId
+            matchRadPixel = matchRadAsec / exposure.getWcs().pixelScale().asArcseconds()
+
+            srcMatches = afwTable.matchXy(selectSources, diaSources, matchRadPixel)
+            srcMatchDict = dict([(srcMatch.second.getId(), srcMatch.first.getId()) for
+                                 srcMatch in srcMatches])
+            self.log.info("Matched %d / %d diaSources to sources" % (len(srcMatchDict),
+                                                                     len(diaSources)))
+        else:
+            self.log.warn("Src product does not exist; cannot match with diaSources")
+            srcMatchDict = {}
+
+        # Create key,val pair where key=diaSourceId and val=refId
+        self.astrometer.matcher.maxMatchDistArcSec = matchRadAsec
+        astromRet = self.astrometer.loadAndMatch(exposure=exposure, sourceCat=selectSources)
+        refMatches = astromRet.matches
+        if refMatches is None:
+            self.log.warn("No diaSource matches with reference catalog")
+            refMatchDict = {}
+        else:
+            self.log.info("Matched %d / %d diaSources to reference catalog" % (len(refMatches),
+                                                                               len(diaSources)))
+            refMatchDict = dict([(refMatch.second.getId(), refMatch.first.getId()) for
+                                 refMatch in refMatches])
+
+        # Assign source Ids
+        for diaSource in diaSources:
+            sid = diaSource.getId()
+            if sid in srcMatchDict:
+                diaSource.set("srcMatchId", srcMatchDict[sid])
+            if sid in refMatchDict:
+                diaSource.set("refMatchId", refMatchDict[sid])
+
+        return diaSources
+
+    def _getConfigName(self):
+        """Return the name of the config dataset
+        """
+        return "%sDiff_config" % (self.config.coaddName,)
+
+    def _getMetadataName(self):
+        """Return the name of the metadata dataset
+        """
+        return "%sDiff_metadata" % (self.config.coaddName,)
+
+    def getSchemaCatalogs(self):
+        """Return a dict of empty catalogs for each catalog dataset produced by this task."""
+        diaSrc = afwTable.SourceCatalog(self.schema)
+        diaSrc.getTable().setMetadata(self.algMetadata)
+        return {self.config.coaddName + "Diff_diaSrc": diaSrc}
+
+    @classmethod
+    def _makeArgumentParser(cls):
+        """Create an argument parser
+        """
+        parser = pipeBase.ArgumentParser(name=cls._DefaultName)
+        parser.add_id_argument("--id", "calexp", help="data ID, e.g. --id visit=12345 ccd=1,2")
+        return parser

--- a/python/lsst/ip/diffim/registerImage.py
+++ b/python/lsst/ip/diffim/registerImage.py
@@ -1,0 +1,192 @@
+#
+# LSST Data Management System
+# Copyright 2008-2013 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""
+This module contains a Task to register (align) multiple images.
+"""
+from __future__ import absolute_import, division, print_function
+from builtins import range
+
+__all__ = ["RegisterTask", "RegisterConfig"]
+
+import math
+import numpy
+
+from lsst.pex.config import Config, Field, ConfigField
+from lsst.pipe.base import Task, Struct
+from lsst.meas.astrom.sip import makeCreateWcsWithSip
+from lsst.afw.math import Warper
+
+import lsst.afw.geom as afwGeom
+import lsst.afw.table as afwTable
+
+
+class RegisterConfig(Config):
+    """Configuration for RegisterTask"""
+    matchRadius = Field(dtype=float, default=1.0, doc="Matching radius (arcsec)", check=lambda x: x > 0)
+    sipOrder = Field(dtype=int, default=4, doc="Order for SIP WCS", check=lambda x: x > 1)
+    sipIter = Field(dtype=int, default=3, doc="Rejection iterations for SIP WCS", check=lambda x: x > 0)
+    sipRej = Field(dtype=float, default=3.0, doc="Rejection threshold for SIP WCS", check=lambda x: x > 0)
+    warper = ConfigField(dtype=Warper.ConfigClass, doc="Configuration for warping")
+
+
+class RegisterTask(Task):
+    """
+    Task to register (align) multiple images.
+
+    The 'run' method provides a revised Wcs from matches and fitting sources.
+    Additional methods are provided as a convenience to warp an exposure
+    ('warpExposure') and sources ('warpSources') with the new Wcs.
+    """
+    ConfigClass = RegisterConfig
+
+    def run(self, inputSources, inputWcs, inputBBox, templateSources):
+        """Register (align) an input exposure to the template
+
+        The sources must have RA,Dec set, and accurate to within the
+        'matchRadius' of the configuration in order to facilitate source
+        matching.  We fit a new Wcs, but do NOT set it in the input exposure.
+
+        @param inputSources: Sources from input exposure
+        @param inputWcs: Wcs of input exposure
+        @param inputBBox: Bounding box of input exposure
+        @param templateSources: Sources from template exposure
+        @return Struct(matches: Matches between sources,
+                       wcs: Wcs for input in frame of template,
+                       )
+        """
+        matches = self.matchSources(inputSources, templateSources)
+        wcs = self.fitWcs(matches, inputWcs, inputBBox)
+        return Struct(matches=matches, wcs=wcs)
+
+    def matchSources(self, inputSources, templateSources):
+        """Match sources between the input and template
+
+        The order of the input arguments matters (because the later Wcs
+        fitting assumes a particular order).
+
+        @param inputSources: Source catalog of the input frame
+        @param templateSources: Source of the target frame
+        @return Match list
+        """
+        matches = afwTable.matchRaDec(templateSources, inputSources,
+                                      self.config.matchRadius*afwGeom.arcseconds)
+        self.log.info("Matching within %.1f arcsec: %d matches" % (self.config.matchRadius, len(matches)))
+        self.metadata.set("MATCH_NUM", len(matches))
+        if len(matches) == 0:
+            raise RuntimeError("Unable to match source catalogs")
+        return matches
+
+    def fitWcs(self, matches, inputWcs, inputBBox):
+        """Fit Wcs to matches
+
+        The fitting includes iterative sigma-clipping.
+
+        @param matches: List of matches (first is target, second is input)
+        @param inputWcs: Original input Wcs
+        @param inputBBox: Bounding box of input image
+        @return Wcs
+        """
+        copyMatches = type(matches)(matches)
+        refCoordKey = copyMatches[0].first.getTable().getCoordKey()
+        inCentroidKey = copyMatches[0].second.getTable().getCentroidKey()
+        for i in range(self.config.sipIter):
+            sipFit = makeCreateWcsWithSip(copyMatches, inputWcs, self.config.sipOrder, inputBBox)
+            self.log.debug("Registration WCS RMS iteration %d: %f pixels",
+                           i, sipFit.getScatterInPixels())
+            wcs = sipFit.getNewWcs()
+            dr = [m.first.get(refCoordKey).angularSeparation(
+                wcs.pixelToSky(m.second.get(inCentroidKey))).asArcseconds() for
+                m in copyMatches]
+            dr = numpy.array(dr)
+            rms = math.sqrt((dr*dr).mean())  # RMS from zero
+            rms = max(rms, 1.0e-9)  # Don't believe any RMS smaller than this
+            self.log.debug("Registration iteration %d: rms=%f", i, rms)
+            good = numpy.where(dr < self.config.sipRej*rms)[0]
+            numBad = len(copyMatches) - len(good)
+            self.log.debug("Registration iteration %d: rejected %d", i, numBad)
+            if numBad == 0:
+                break
+            copyMatches = type(matches)(copyMatches[i] for i in good)
+
+        sipFit = makeCreateWcsWithSip(copyMatches, inputWcs, self.config.sipOrder, inputBBox)
+        self.log.info("Registration WCS: final WCS RMS=%f pixels from %d matches" %
+                      (sipFit.getScatterInPixels(), len(copyMatches)))
+        self.metadata.set("SIP_RMS", sipFit.getScatterInPixels())
+        self.metadata.set("SIP_GOOD", len(copyMatches))
+        self.metadata.set("SIP_REJECTED", len(matches) - len(copyMatches))
+        wcs = sipFit.getNewWcs()
+        return wcs
+
+    def warpExposure(self, inputExp, newWcs, templateWcs, templateBBox):
+        """Warp input exposure to template frame
+
+        There are a variety of data attached to the exposure (e.g., PSF, Calib
+        and other metadata), but we do not attempt to warp these to the template
+        frame.
+
+        @param inputExp: Input exposure, to be warped
+        @param newWcs: Revised Wcs for input exposure
+        @param templateWcs: Target Wcs
+        @param templateBBox: Target bounding box
+        @return Warped exposure
+        """
+        warper = Warper.fromConfig(self.config.warper)
+        copyExp = inputExp.Factory(inputExp.getMaskedImage(), newWcs)
+        alignedExp = warper.warpExposure(templateWcs, copyExp, destBBox=templateBBox)
+        return alignedExp
+
+    def warpSources(self, inputSources, newWcs, templateWcs, templateBBox):
+        """Warp sources to the new frame
+
+        It would be difficult to transform all possible quantities of potential
+        interest between the two frames.  We therefore update only the sky and
+        pixel coordinates.
+
+        @param inputSources: Sources on input exposure, to be warped
+        @param newWcs: Revised Wcs for input exposure
+        @param templateWcs: Target Wcs
+        @param templateBBox: Target bounding box
+        @return Warped sources
+        """
+        alignedSources = inputSources.copy(True)
+        if not isinstance(templateBBox, afwGeom.Box2D):
+            # There is no method Box2I::contains(Point2D)
+            templateBBox = afwGeom.Box2D(templateBBox)
+        table = alignedSources.getTable()
+        coordKey = table.getCoordKey()
+        centroidKey = table.getCentroidKey()
+        deleteList = []
+        for i, s in enumerate(alignedSources):
+            oldCentroid = s.get(centroidKey)
+            newCoord = newWcs.pixelToSky(oldCentroid)
+            newCentroid = templateWcs.skyToPixel(newCoord)
+            if not templateBBox.contains(newCentroid):
+                deleteList.append(i)
+                continue
+            s.set(coordKey, newCoord)
+            s.set(centroidKey, newCentroid)
+
+        for i in reversed(deleteList):  # Delete from back so we don't change indices
+            del alignedSources[i]
+
+        return alignedSources

--- a/tests/test_Register.py
+++ b/tests/test_Register.py
@@ -1,0 +1,231 @@
+from __future__ import division, print_function, absolute_import
+from builtins import zip
+from builtins import range
+#!/usr/bin/env python
+#
+# LSST Data Management System
+# Copyright 2008-2013 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+
+import numpy as np
+
+import lsst.utils.tests
+import lsst.afw.image as afwImage
+import lsst.afw.table as afwTable
+import lsst.afw.coord as afwCoord
+import lsst.afw.geom as afwGeom
+import lsst.afw.display.ds9 as ds9
+from lsst.pipe.base import Struct
+#from lsst.pipe.tasks.registerImage import RegisterConfig, RegisterTask
+from lsst.ip.diffim.registerImage import RegisterConfig, RegisterTask
+
+try:
+    display
+except NameError:
+    display = False
+
+
+class RegisterTestCase(unittest.TestCase):
+
+    """A test case for RegisterTask."""
+
+    def setUp(self):
+        self.dx = -5
+        self.dy = +3
+        self.numSources = 123
+        self.border = 10  # Must be larger than dx,dy
+        self.width = 1000
+        self.height = 1000
+        self.pixelScale = 0.1 * afwGeom.arcseconds  # So dx,dy is not larger than RegisterConfig.matchRadius
+
+    def tearDown(self):
+        del self.pixelScale
+
+    def create(self):
+        """Create test images and sources
+
+        We will create two fake images with some 'sources', which are just single bright pixels.
+        The images will have the same sources with a constant offset between them.  The WCSes
+        of the two images are identical, despite the offset; this simulates a small e.g., pointing
+        error, or misalignment that the RegisterTask should rectify.
+        """
+        np.random.seed(0)
+        templateImage = afwImage.MaskedImageF(self.width, self.height)
+        templateImage.set(0)
+        inputImage = afwImage.MaskedImageF(self.width, self.height)
+        inputImage.set(0)
+
+        templateArray = templateImage.getImage().getArray()
+        inputArray = inputImage.getImage().getArray()
+
+        # Sources are at integer positions to ensure warped pixels have value of unity
+        xTemplate = np.random.randint(self.border, self.width - self.border, self.numSources)
+        yTemplate = np.random.randint(self.border, self.width - self.border, self.numSources)
+        xInput = xTemplate + self.dx
+        yInput = yTemplate + self.dy
+
+        # Note: numpy indices are backwards: [y,x]
+        templateArray[(yTemplate).astype(int), (xTemplate).astype(int)] = 1
+        inputArray[(yInput).astype(int), (xInput).astype(int)] = 1
+
+        # Create WCSes
+        centerCoord = afwCoord.IcrsCoord(0*afwGeom.degrees, 0*afwGeom.degrees)
+        centerPixel = afwGeom.Point2D(self.width/2, self.height/2)
+        wcs = afwImage.makeWcs(centerCoord, centerPixel, self.pixelScale.asDegrees(), 0, 0,
+                               self.pixelScale.asDegrees())
+
+        # Note that one of the WCSes must be "wrong", since they are the same, but the sources are offset.
+        # It is the job of the RegisterTask to align the images, despite the "wrong" WCS.
+        templateExp = afwImage.makeExposure(templateImage, wcs)
+        inputExp = afwImage.makeExposure(inputImage, wcs)
+
+        # Generate catalogues
+        schema = afwTable.SourceTable.makeMinimalSchema()
+        centroidKey = afwTable.Point2DKey.addFields(schema, "center", "center", "pixel")
+
+        def newCatalog():
+            catalog = afwTable.SourceCatalog(schema)
+            catalog.getTable().defineCentroid("center")
+            return catalog
+
+        templateSources = newCatalog()
+        inputSources = newCatalog()
+
+        coordKey = templateSources.getCoordKey()
+        for xt, yt, xi, yi in zip(xTemplate, yTemplate, xInput, yInput):
+            tRecord = templateSources.addNew()
+            iRecord = inputSources.addNew()
+
+            tPoint = afwGeom.Point2D(float(xt), float(yt))
+            iPoint = afwGeom.Point2D(float(xi), float(yi))
+
+            tRecord.set(centroidKey, tPoint)
+            iRecord.set(centroidKey, iPoint)
+            tRecord.set(coordKey, wcs.pixelToSky(tPoint))
+            iRecord.set(coordKey, wcs.pixelToSky(iPoint))
+
+        self.showImage(inputExp, inputSources, "Input", 1)
+        self.showImage(templateExp, templateSources, "Template", 2)
+
+        return Struct(xInput=xInput, yInput=yInput, xTemplate=xTemplate, yTemplate=yTemplate, wcs=wcs,
+                      inputExp=inputExp, inputSources=inputSources,
+                      templateExp=templateExp, templateSources=templateSources)
+
+    def runTask(self, inData, config=RegisterConfig()):
+        """Run the task on the data"""
+        config.sipOrder = 2
+        task = RegisterTask(name="register", config=config)
+        results = task.run(inData.inputSources, inData.inputExp.getWcs(),
+                           inData.inputExp.getBBox(afwImage.LOCAL), inData.templateSources)
+        warpedExp = task.warpExposure(inData.inputExp, results.wcs, inData.templateExp.getWcs(),
+                                      inData.templateExp.getBBox(afwImage.LOCAL))
+        warpedSources = task.warpSources(inData.inputSources, results.wcs, inData.templateExp.getWcs(),
+                                         inData.templateExp.getBBox(afwImage.LOCAL))
+
+        self.showImage(warpedExp, warpedSources, "Aligned", 3)
+        return Struct(warpedExp=warpedExp, warpedSources=warpedSources, matches=results.matches,
+                      wcs=results.wcs, task=task)
+
+    def assertRegistered(self, inData, outData, bad=set()):
+        """Assert that the registration task is registering images"""
+        xTemplate = np.array([x for i, x in enumerate(inData.xTemplate) if i not in bad])
+        yTemplate = np.array([y for i, y in enumerate(inData.yTemplate) if i not in bad])
+        alignedArray = outData.warpedExp.getMaskedImage().getImage().getArray()
+        self.assertTrue((alignedArray[yTemplate, xTemplate] == 1.0).all())
+        for dx in (-1, 0, +1):
+            for dy in range(-1, 0, +1):
+                # The density of points is such that I can assume that no point is next to another.
+                # The values are not quite zero because the "image" is undersampled, so we get ringing.
+                self.assertTrue((alignedArray[yTemplate+dy, xTemplate+dx] < 0.1).all())
+
+        xAligned = np.array([x for i, x in enumerate(outData.warpedSources["center_x"]) if i not in bad])
+        yAligned = np.array([y for i, y in enumerate(outData.warpedSources["center_y"]) if i not in bad])
+        self.assertAlmostEqual((xAligned - xTemplate).mean(), 0, 8)
+        self.assertAlmostEqual((xAligned - xTemplate).std(), 0, 8)
+        self.assertAlmostEqual((yAligned - yTemplate).mean(), 0, 8)
+        self.assertAlmostEqual((yAligned - yTemplate).std(), 0, 8)
+
+    def assertMetadata(self, outData, numRejected=0):
+        """Assert that the registration task is populating the metadata"""
+        metadata = outData.task.metadata
+        self.assertEqual(metadata.get("MATCH_NUM"), self.numSources)
+        self.assertAlmostEqual(metadata.get("SIP_RMS"), 0.0)
+        self.assertEqual(metadata.get("SIP_GOOD"), self.numSources-numRejected)
+        self.assertEqual(metadata.get("SIP_REJECTED"), numRejected)
+
+    def testRegister(self):
+        """Test image registration"""
+        inData = self.create()
+        outData = self.runTask(inData)
+        self.assertRegistered(inData, outData)
+        self.assertMetadata(outData)
+
+    def testRejection(self):
+        """Test image registration with rejection"""
+        inData = self.create()
+
+        # Tweak a source to have a bad offset
+        badIndex = 111
+
+        coordKey = inData.inputSources[badIndex].getTable().getCoordKey()
+        centroidKey = inData.inputSources[badIndex].getTable().getCentroidKey()
+        x, y = float(inData.xInput[badIndex] + 0.01), float(inData.yInput[badIndex] - 0.01)
+        point = afwGeom.Point2D(x, y)
+        inData.inputSources[badIndex].set(centroidKey, point)
+        inData.inputSources[badIndex].set(coordKey, inData.wcs.pixelToSky(point))
+
+        config = RegisterConfig()
+        config.sipRej = 10.0
+
+        outData = self.runTask(inData)
+        self.assertRegistered(inData, outData, bad=set([badIndex]))
+        self.assertMetadata(outData, numRejected=1)
+
+    def showImage(self, image, sources, title, frame):
+        """Display an image
+
+        Images are only displayed if 'display' is turned on.
+
+        @param image: Image to display
+        @param sources: Sources to mark on the display
+        @param title: Title to give frame
+        @param frame: Frame on which to display
+        """
+        if not display:
+            return
+        ds9.mtv(image, title=title, frame=frame)
+        with ds9.Buffering():
+            for s in sources:
+                center = s.getCentroid()
+                ds9.dot("o", center.getX(), center.getY(), frame=frame)
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
- Fix imports, configs, schemas
- Get individual command-line tasks to work
- Refactor runMatchSources in new function
- Start fixing docstrings
- Fix match-sources to correctly load ref-cat if avail
- Make tasks more robust
- Ensure saving of masked/subtracted exposures and diaSrces
  when run from imageDifference.py
- Robustify Zogy in spatially varying mode
- Allow no matchedExposure for use in dipole fitting (it is not
  produced by Zogy(spatiallyVarying)
- Improve logging messages