### PR TITLE
DM-13609: Undo EXTRACT_PRIVATE override in ip_diffim

### DIFF
--- a/doc/doxygen.conf.in
+++ b/doc/doxygen.conf.in
@@ -1,2 +1,1 @@
-EXTRACT_PRIVATE = YES
 EXAMPLE_PATH = examples python/lsst/ip/diffim


### PR DESCRIPTION
This PR implements [RFC-451](https://jira.lsstcorp.org/browse/RFC-451) by making `ip_diffim` use the default documentation level (public+protected). The change has been tested locally with both package- and stack-level documentation builds.