### PR TITLE
Tickets/dm-15636: Improve DcrModel regularization

### DIFF
--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -377,34 +377,32 @@ class DcrModel:
         templateExposure.setFilter(self.filter)
         return templateExposure
 
-    def conditionDcrModel(self, subfilter, newModel, bbox, gain=1.):
+    def conditionDcrModel(self, modelImages, bbox, gain=1.):
         """Average two iterations' solutions to reduce oscillations.
 
         Parameters
         ----------
-        subfilter : `int`
-            Index of the current subfilter within the full band.
-        newModel : `lsst.afw.image.MaskedImage`
-            The new DCR model for one subfilter from the current iteration.
-            Values in ``newModel`` that are extreme compared with the last
-            iteration are modified in place.
+        modelImages : `list` of `lsst.afw.image.MaskedImage`
+            The new DCR model images from the current iteration.
+            The values will be modified in place.
         bbox : `lsst.afw.geom.Box2I`
             Sub-region of the coadd
         gain : `float`, optional
-            Additional weight to apply to the model from the current iteration.
+            Relative weight to give the new solution when updating the model.
             Defaults to 1.0, which gives equal weight to both solutions.
         """
         # Calculate weighted averages of the image and variance planes.
         # Note that ``newModel *= gain`` would multiply the variance by ``gain**2``
-        newModel.image *= gain
-        newModel.image += self[subfilter][bbox].image
-        newModel.image /= 1. + gain
-        newModel.variance *= gain
-        newModel.variance += self[subfilter][bbox].variance
-        newModel.variance /= 1. + gain
-
     def clampModel(self, subfilter, newModel, bbox, statsCtrl, regularizeSigma, modelClampFactor,
                    convergenceMaskPlanes="DETECTED"):
+        for model, newModel in zip(self, modelImages):
+            newModel.image *= gain
+            newModel.image += model[bbox].image
+            newModel.image /= 1. + gain
+            newModel.variance *= gain
+            newModel.variance += model[bbox].variance
+            newModel.variance /= 1. + gain
+
         """Restrict large variations in the model between iterations.
 
         Parameters

--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -461,7 +461,7 @@ class DcrModel:
         maskedImage : `lsst.afw.image.MaskedImage`
             The input image to evaluate the background noise properties.
         statsCtrl : `lsst.afw.math.StatisticsControl`
-            Statistics control object for coadd
+            Statistics control object for coaddition.
         bufferSize : `int`
             Number of additional pixels to exclude
             from the edges of the bounding box.
@@ -519,13 +519,13 @@ class DcrModel:
         image = maskedImage.image.array
         filterStructure = ndimage.iterate_structure(ndimage.generate_binary_structure(2, 1),
                                                     regularizationWidth)
-        if highThreshold is not None:
+        if highThreshold:
             highPixels = image > highThreshold
             if regularizationWidth > 0:
                 # Erode and dilate ``highPixels`` to exclude noisy pixels.
                 highPixels = ndimage.morphology.binary_opening(highPixels, structure=filterStructure)
             image[highPixels] = highThreshold[highPixels]
-        if lowThreshold is not None:
+        if lowThreshold:
             lowPixels = image < lowThreshold
             if regularizationWidth > 0:
                 # Erode and dilate ``lowPixels`` to exclude noisy pixels.

--- a/tests/test_dcrModel.py
+++ b/tests/test_dcrModel.py
@@ -217,10 +217,10 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
         This additionally tests that the variance and mask planes do not change.
         """
         dcrModels = DcrModel(modelImages=self.makeTestImages())
-        newModels = [dcrModels[subfilter].clone() for subfilter in range(self.dcrNumSubfilters)]
-        for subfilter, newModel in enumerate(newModels):
-            dcrModels.conditionDcrModel(subfilter, newModel, self.bbox, gain=1.)
-            self.assertMaskedImagesEqual(dcrModels[subfilter], newModel)
+        newModels = [model.clone() for model in dcrModels]
+        dcrModels.conditionDcrModel(newModels, self.bbox, gain=1.)
+        for refModel, newModel in zip(dcrModels, newModels):
+            self.assertMaskedImagesEqual(refModel, newModel)
 
     def testConditionDcrModelNoChangeHighGain(self):
         """Conditioning should not change the model if it equals the reference.
@@ -228,10 +228,10 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
         This additionally tests that the variance and mask planes do not change.
         """
         dcrModels = DcrModel(modelImages=self.makeTestImages())
-        newModels = [dcrModels[subfilter].clone() for subfilter in range(self.dcrNumSubfilters)]
-        for subfilter, newModel in enumerate(newModels):
-            dcrModels.conditionDcrModel(subfilter, newModel, self.bbox, gain=2.5)
-            self.assertMaskedImagesAlmostEqual(dcrModels[subfilter], newModel)
+        newModels = [model.clone() for model in dcrModels]
+        dcrModels.conditionDcrModel(newModels, self.bbox, gain=2.5)
+        for refModel, newModel in zip(dcrModels, newModels):
+            self.assertMaskedImagesAlmostEqual(refModel, newModel)
 
     def testConditionDcrModelWithChange(self):
         """Verify conditioning when the model changes by a known amount.
@@ -239,12 +239,11 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
         This additionally tests that the variance and mask planes do not change.
         """
         dcrModels = DcrModel(modelImages=self.makeTestImages())
-        newModels = [dcrModels[subfilter].clone() for subfilter in range(self.dcrNumSubfilters)]
+        newModels = [model.clone() for model in dcrModels]
         for model in newModels:
             model.image.array[:] *= 3.
-        for subfilter, newModel in enumerate(newModels):
-            dcrModels.conditionDcrModel(subfilter, newModel, self.bbox, gain=1.)
-            refModel = dcrModels[subfilter]
+        dcrModels.conditionDcrModel(newModels, self.bbox, gain=1.)
+        for refModel, newModel in zip(dcrModels, newModels):
             refModel.image.array[:] *= 2.
             self.assertMaskedImagesAlmostEqual(refModel, newModel)
 

--- a/tests/test_dcrModel.py
+++ b/tests/test_dcrModel.py
@@ -258,10 +258,10 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
         dcrModels = DcrModel(modelImages=self.makeTestImages())
         statsCtrl = afwMath.StatisticsControl()
         refModels = [dcrModels[subfilter].clone() for subfilter in range(self.dcrNumSubfilters)]
-        mask = refModels[0].mask
         dcrModels.regularizeModel(self.bbox, mask, statsCtrl, regularizeSigma, clampFrequency)
         for subfilter, refModel in enumerate(refModels):
             self.assertMaskedImagesEqual(dcrModels[subfilter], refModel)
+        mask = dcrModels.mask
 
     def testRegularizationSmallClamp(self):
         """Test that large variations between model planes are reduced.
@@ -273,7 +273,7 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
         dcrModels = DcrModel(modelImages=self.makeTestImages())
         statsCtrl = afwMath.StatisticsControl()
         refModels = [dcrModels[subfilter].clone() for subfilter in range(self.dcrNumSubfilters)]
-        mask = refModels[0].mask
+        mask = dcrModels.mask
         templateImage = dcrModels.getReferenceImage(self.bbox)
 
         dcrModels.regularizeModel(self.bbox, mask, statsCtrl, regularizeSigma, clampFrequency)


### PR DESCRIPTION
These changes provide greater flexibility in applying regularization to DcrModels between iterations and between frequencies, and reduce artifacts in the final images.