### PR TITLE
DM-16536: Migrate all metrics from ap.verify.measurements

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 Copyright 2015-2019 The Trustees of Princeton University
-Copyright 2014-2018 University of Washington
+Copyright 2014-2019 University of Washington
 Copyright 2015-2016, 2018 Association of Universities for Research in Astronomy
 Copyright 2014-2015, 2017 The Regents of the University of California
 Copyright 2016 University of Illinois Board of Trustees

--- a/doc/lsst.ip.diffim/index.rst
+++ b/doc/lsst.ip.diffim/index.rst
@@ -8,7 +8,15 @@ lsst.ip.diffim
 
 The ``lsst.ip.diffim`` module provides algorithms for astronomical image differencing.
 
-.. Add subsections with toctree to individual topic pages.
+.. _lsst.ip.diffim-using:
+
+Using lsst.ip.diffim
+====================
+
+.. toctree linking to topics related to using the module's APIs.
+
+.. toctree::
+   :maxdepth: 1
 
 .. _lsst.ip.diffim-contributing:
 
@@ -18,6 +26,29 @@ Contributing
 ``lsst.ip.diffim`` is developed at https://github.com/lsst/ip_diffim.
 You can find Jira issues for this module under the `ip_diffim <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ip_diffim>`_ component.
 
+.. _lsst.ip.diffim-command-line-taskref:
+
+Task reference
+==============
+
+.. _lsst.ip.diffim-tasks:
+
+Tasks
+-----
+
+.. lsst-tasks::
+   :root: lsst.ip.diffim
+   :toctree: tasks
+
+.. _lsst.ip.diffim-configs:
+
+Configurations
+--------------
+
+.. lsst-configs::
+   :root: lsst.ip.diffim
+   :toctree: configs
+
 .. _lsst.ip.diffim-pyapi:
 
 Python API reference
@@ -26,3 +57,7 @@ Python API reference
 .. automodapi:: lsst.ip.diffim
    :no-main-docstr:
    :skip: wrapSimpleAlgorithm
+
+.. automodapi:: lsst.ip.diffim.metrics
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask.rst
+++ b/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask.rst
@@ -1,0 +1,51 @@
+.. lsst-task-topic:: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
+
+########################################
+FractionDiaSourcesToSciSourcesMetricTask
+########################################
+
+``FractionDiaSourcesToSciSourcesMetricTask`` computes the fraction of science sources that become DIASources when processed through image differencing (as the ``ip_diffim.fracDiaSourcesToSciSources`` metric).
+It requires source catalogs as input, and can operate at image-level or coarser granularity.
+
+.. _lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask-summary:
+
+Processing summary
+==================
+
+``FractionDiaSourcesToSciSourcesMetricTask`` reads source catalogs (``src`` and ``deepDiff_diaSrc`` datasets, by default) and counts the number of sources.
+It then computes the ratio of DIASources to science sources for those catalogs.
+
+.. _lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
+
+.. _lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~_lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricConfig.sciSources`
+    The catalog type for science sources (default: ``src``).
+
+:lsst-config-field:`~_lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricConfig.diaSources`
+    The catalog type for DIASources (default: ``deepDiff_diaSrc``).
+
+.. _lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
+
+.. _lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask

--- a/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.NumberSciSourcesMetricTask.rst
+++ b/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.NumberSciSourcesMetricTask.rst
@@ -1,0 +1,47 @@
+.. lsst-task-topic:: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask
+
+##########################
+NumberSciSourcesMetricTask
+##########################
+
+``NumberSciSourcesMetricTask`` computes the number of science sources created when processing data through image differencing (as the ``ip_diffim.numSciSources`` metric).
+It requires source catalogs (a ``src`` dataset) as input, and can operate at image-level or coarser granularity.
+
+.. _lsst.ip.diffim.metrics.NumberSciSourcesMetricTask-summary:
+
+Processing summary
+==================
+
+``FractionDiaSourcesToSciSourcesMetricTask`` reads source catalogs (``src`` datasets) and adds up the number of sources in those catalogs.
+
+.. _lsst.ip.diffim.metrics.NumberSciSourcesMetricTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask
+
+.. _lsst.ip.diffim.metrics.NumberSciSourcesMetricTask-butler:
+
+Butler datasets
+===============
+
+Input datasets
+--------------
+
+:lsst-config-field:`~_lsst.ip.diffim.metrics.NumberSciSourcesMetricConfig.sources`
+    The catalog type for science sources (default: ``src``).
+
+.. _lsst.ip.diffim.metrics.NumberSciSourcesMetricTask-subtasks:
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask
+
+.. _lsst.ip.diffim.metrics.NumberSciSourcesMetricTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask

--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -574,7 +574,7 @@ def applyDcr(image, dcr, useInverse=False, splitSubfilters=False, **kwargs):
     dcr : `tuple`
         Shift calculated with ``calculateDcr``.
         Uses numpy axes ordering (Y, X).
-        If ``splitSubfilters` is set, each element is itself a `tuple`
+        If ``splitSubfilters`` is set, each element is itself a `tuple`
         of two `float`, corresponding to the DCR shift at the two wavelengths.
         Otherwise, each element is a `float` corresponding to the DCR shift at
         the effective wavelength of the subfilter.

--- a/python/lsst/ip/diffim/dipoleFitTask.py
+++ b/python/lsst/ip/diffim/dipoleFitTask.py
@@ -791,12 +791,13 @@ class DipoleFitAlgorithm(object):
             Weighting of posImage/negImage relative to the diffim in the fit
         fitBackground : `int`, {0, 1, 2}, optional
             How to fit linear background gradient in posImage/negImage
+
             - 0: do not fit background at all
             - 1 (default): pre-fit the background using linear least squares and then do not fit it as part
-                 of the dipole fitting optimization
+              of the dipole fitting optimization
             - 2: pre-fit the background using linear least squares (as in 1), and use the parameter
-                 estimates from that fit as starting parameters for an integrated "re-fit" of the background
-                 as part of the overall dipole fitting optimization.
+              estimates from that fit as starting parameters for an integrated "re-fit" of the background
+              as part of the overall dipole fitting optimization.
         maxSepInSigma : `float`, optional
             Allowed window of centroid parameters relative to peak in input source footprint
         separateNegParams : `bool`, optional

--- a/python/lsst/ip/diffim/imagePsfMatch.py
+++ b/python/lsst/ip/diffim/imagePsfMatch.py
@@ -139,10 +139,10 @@ class ImagePsfMatchTask(PsfMatchTask):
 
     There is no run() method for this Task.  Instead there are 4 methods that
     may be used to invoke the Psf-matching.  These are
-    lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.matchMaskedImages matchMaskedImages
-    lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.subtractMaskedImages subtractMaskedImages,
-    lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.matchExposures matchExposures, and
-    lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.subtractExposures subtractExposures.
+    `~lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.matchMaskedImages`,
+    `~lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.subtractMaskedImages`,
+    `~lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.matchExposures`, and
+    `~lsst.ip.diffim.imagePsfMatch.ImagePsfMatchTask.subtractExposures`.
 
     The methods that operate on lsst.afw.image.MaskedImage require that the images already be astrometrically
     aligned, and are the same shape.  The methods that operate on lsst.afw.image.Exposure allow for the

--- a/python/lsst/ip/diffim/metrics.py
+++ b/python/lsst/ip/diffim/metrics.py
@@ -1,0 +1,161 @@
+# This file is part of ip_diffim.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+__all__ = [
+    "NumberSciSourcesMetricTask", "NumberSciSourcesMetricConfig",
+    "FractionDiaSourcesToSciSourcesMetricTask", "FractionDiaSourcesToSciSourcesMetricConfig",
+]
+
+
+import astropy.units as u
+
+from lsst.pipe.base import Struct, InputDatasetField
+from lsst.verify import Measurement
+from lsst.verify.gen2tasks import MetricTask, register
+from lsst.verify.tasks import MetricComputationError
+
+
+class NumberSciSourcesMetricConfig(MetricTask.ConfigClass):
+    sources = InputDatasetField(
+        doc="The catalog of science sources.",
+        name="src",
+        storageClass="SourceCatalog",
+        dimensions={"Instrument", "Exposure", "Detector"},
+    )
+
+
+@register("numSciSources")
+class NumberSciSourcesMetricTask(MetricTask):
+    """Task that computes the number of cataloged science sources.
+    """
+    _DefaultName = "numSciSources"
+    ConfigClass = NumberSciSourcesMetricConfig
+
+    def run(self, sources):
+        """Count the number of science sources.
+
+        Parameters
+        ----------
+        sources : iterable of `lsst.afw.table.SourceCatalog`
+            A collection of science source catalogs, one for each unit of
+            processing to be incorporated into this metric. Its elements may
+            be `None` to represent missing data.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            ``measurement``
+                the total number of science sources (`lsst.verify.Measurement`
+                or `None`)
+        """
+        nSciSources = 0
+        inputData = False
+        for catalog in sources:
+            if catalog is not None:
+                nSciSources += len(catalog)
+                inputData = True
+
+        if inputData:
+            meas = Measurement(self.getOutputMetricName(self.config), nSciSources * u.count)
+        else:
+            self.log.info("Nothing to do: no catalogs found.")
+            meas = None
+        return Struct(measurement=meas)
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return "ip_diffim.numSciSources"
+
+
+class FractionDiaSourcesToSciSourcesMetricConfig(MetricTask.ConfigClass):
+    sciSources = InputDatasetField(
+        doc="The catalog of science sources.",
+        name="src",
+        storageClass="SourceCatalog",
+        dimensions={"Instrument", "Exposure", "Detector"},
+    )
+    diaSources = InputDatasetField(
+        doc="The catalog of DIASources.",
+        name="deepDiff_diaSrc",
+        nameTemplate="{coaddName}Diff_diaSrc",
+        storageClass="SourceCatalog",
+        dimensions={"Instrument", "Exposure", "Detector"},
+    )
+
+
+@register("fracDiaSourcesToSciSources")
+class FractionDiaSourcesToSciSourcesMetricTask(MetricTask):
+    """Task that computes the ratio of difference image sources to science
+    sources in an image, visit, etc.
+    """
+    _DefaultName = "fracDiaSourcesToSciSources"
+    ConfigClass = FractionDiaSourcesToSciSourcesMetricConfig
+
+    def run(self, sciSources, diaSources):
+        """Compute the ratio of DIASources to science sources.
+
+        Parameters
+        ----------
+        sciSources : iterable of `lsst.afw.table.SourceCatalog`
+            A collection of science source catalogs, one for each unit of
+            processing to be incorporated into this metric. Its elements may
+            be `None` to represent missing data.
+        diaSources : iterable of `lsst.afw.table.SourceCatalog`
+            A collection of difference imaging catalogs similar to
+            ``sciSources``.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            ``measurement``
+                the ratio (`lsst.verify.Measurement` or `None`)
+        """
+        nSciSources = 0
+        nDiaSources = 0
+        inputData = False
+
+        for sciCatalog, diaCatalog in zip(sciSources, diaSources):
+            if diaCatalog is not None and sciCatalog is not None:
+                nSciSources += len(sciCatalog)
+                nDiaSources += len(diaCatalog)
+                inputData = True
+
+        if inputData:
+            metricName = self.getOutputMetricName(self.config)
+            if nSciSources <= 0.0:
+                raise MetricComputationError(
+                    "No science sources found; ratio of DIASources to science sources ill-defined.")
+                meas = Measurement(metricName, 0.0 * u.dimensionless_unscaled)
+            else:
+                meas = Measurement(metricName, nDiaSources / nSciSources * u.dimensionless_unscaled)
+        else:
+            self.log.info("Nothing to do: no catalogs found.")
+            meas = None
+        return Struct(measurement=meas)
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return "ip_diffim.fracDiaSourcesToSciSources"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,207 @@
+# This file is part of ip_diffim.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+
+from lsst.afw.table import SourceCatalog
+import lsst.utils.tests
+from lsst.verify import Name
+from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
+from lsst.verify.tasks import MetricComputationError
+
+from lsst.ip.diffim.metrics import \
+    NumberSciSourcesMetricTask, \
+    FractionDiaSourcesToSciSourcesMetricTask
+
+
+def _makeDummyCatalog(size):
+    catalog = SourceCatalog(SourceCatalog.Table.makeMinimalSchema())
+    for i in range(size):
+        catalog.addNew()
+    return catalog
+
+
+class TestNumSciSources(MetricTaskTestCase):
+
+    @classmethod
+    def makeTask(cls):
+        return NumberSciSourcesMetricTask()
+
+    def testValid(self):
+        catalog = _makeDummyCatalog(3)
+        result = self.task.run([catalog])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ip_diffim.numSciSources"))
+        self.assertEqual(meas.quantity, len(catalog) * u.count)
+
+    def testEmptyCatalog(self):
+        catalog = _makeDummyCatalog(0)
+        result = self.task.run([catalog])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ip_diffim.numSciSources"))
+        self.assertEqual(meas.quantity, 0 * u.count)
+
+    def testMissingData(self):
+        result = self.task.run([None])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testNoDataExpected(self):
+        result = self.task.run([])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testGetInputDatasetTypes(self):
+        config = self.taskClass.ConfigClass()
+        types = self.taskClass.getInputDatasetTypes(config)
+        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
+        self.assertSetEqual(set(types.keys()), {"sources"})
+        self.assertEqual(types["sources"], "src")
+
+    def testFineGrainedMetric(self):
+        catalog = _makeDummyCatalog(3)
+        inputData = {"sources": [catalog]}
+        inputDataIds = {"sources": [{"visit": 42, "ccd": 1}]}
+        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
+        measDirect = self.task.run([catalog]).measurement
+        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
+
+    def testCoarseGrainedMetric(self):
+        catalog = _makeDummyCatalog(3)
+        nCcds = 3
+        inputData = {"sources": [catalog] * nCcds}
+        inputDataIds = {"sources": [{"visit": 42, "ccd": x} for x in range(nCcds)]}
+        outputDataId = {"measurement": {"visit": 42}}
+        measDirect = self.task.run([catalog]).measurement
+        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measMany.quantity, nCcds * measDirect.quantity)
+
+
+class TestFractionDiaSources(MetricTaskTestCase):
+
+    @classmethod
+    def makeTask(cls):
+        return FractionDiaSourcesToSciSourcesMetricTask()
+
+    def testValid(self):
+        sciCatalog = _makeDummyCatalog(5)
+        diaCatalog = _makeDummyCatalog(3)
+        result = self.task.run([sciCatalog], [diaCatalog])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ip_diffim.fracDiaSourcesToSciSources"))
+        self.assertEqual(meas.quantity, len(diaCatalog) / len(sciCatalog) * u.dimensionless_unscaled)
+
+    def testEmptyDiaCatalog(self):
+        sciCatalog = _makeDummyCatalog(5)
+        diaCatalog = _makeDummyCatalog(0)
+        result = self.task.run([sciCatalog], [diaCatalog])
+        meas = result.measurement
+
+        self.assertEqual(meas.metric_name, Name(metric="ip_diffim.fracDiaSourcesToSciSources"))
+        self.assertEqual(meas.quantity, 0.0 * u.dimensionless_unscaled)
+
+    def testEmptySciCatalog(self):
+        sciCatalog = _makeDummyCatalog(0)
+        diaCatalog = _makeDummyCatalog(3)
+        with self.assertRaises(MetricComputationError):
+            self.task.run([sciCatalog], [diaCatalog])
+
+    def testEmptyCatalogs(self):
+        sciCatalog = _makeDummyCatalog(0)
+        diaCatalog = _makeDummyCatalog(0)
+        with self.assertRaises(MetricComputationError):
+            self.task.run([sciCatalog], [diaCatalog])
+
+    def testMissingData(self):
+        result = self.task.run([None], [None])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testSemiMissingData(self):
+        result = self.task.run(sciSources=[_makeDummyCatalog(3)], diaSources=[None])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testNoDataExpected(self):
+        result = self.task.run([], [])
+        meas = result.measurement
+        self.assertIsNone(meas)
+
+    def testGetInputDatasetTypes(self):
+        config = self.taskClass.ConfigClass()
+        types = self.taskClass.getInputDatasetTypes(config)
+        # dict.keys() is a collections.abc.Set, which has a narrower interface than __builtins__.set...
+        self.assertSetEqual(set(types.keys()), {"sciSources", "diaSources"})
+        self.assertEqual(types["sciSources"], "src")
+        self.assertEqual(types["diaSources"], "deepDiff_diaSrc")
+
+    # TODO: add a test for the templating in FractionDiaSourcesToSciSourcesMetricConfig
+    # once we've migrated to PipelineTaskConfig
+
+    def testFineGrainedMetric(self):
+        sciCatalog = _makeDummyCatalog(5)
+        diaCatalog = _makeDummyCatalog(1)
+        inputData = {"sciSources": [sciCatalog], "diaSources": [diaCatalog]}
+        inputDataIds = {"sciSources": [{"visit": 42, "ccd": 1}], "diaSources": [{"visit": 42, "ccd": 1}]}
+        outputDataId = {"measurement": {"visit": 42, "ccd": 1}}
+        measDirect = self.task.run([sciCatalog], [diaCatalog]).measurement
+        measIndirect = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measIndirect.quantity, measDirect.quantity)
+
+    def testCoarseGrainedMetric(self):
+        sciCatalog = _makeDummyCatalog(5)
+        diaCatalog = _makeDummyCatalog(1)
+        nCcds = 3
+        inputData = {"sciSources": [sciCatalog] * nCcds, "diaSources": [diaCatalog] * nCcds}
+        dataIds = [{"visit": 42, "ccd": x} for x in range(nCcds)]
+        inputDataIds = {"sciSources": dataIds, "diaSources": dataIds}
+        outputDataId = {"measurement": {"visit": 42}}
+        measDirect = self.task.run([sciCatalog], [diaCatalog]).measurement
+        measMany = self.task.adaptArgsAndRun(inputData, inputDataIds, outputDataId).measurement
+
+        assert_quantity_allclose(measMany.quantity, measDirect.quantity)
+
+
+# Hack around unittest's hacky test setup system
+del MetricTaskTestCase
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/ups/ip_diffim.table
+++ b/ups/ip_diffim.table
@@ -13,6 +13,7 @@ setupRequired(pipe_base)
 setupRequired(utils)
 setupRequired(lmfit)
 setupRequired(pybind11)
+setupRequired(verify)
 
 setupOptional(afwdata)
 setupOptional(matplotlib)


### PR DESCRIPTION
This PR defines `MetricTask` subclasses for the `ip_diffim.numSciSources` and `ip_diffim.fracDiaSourcesToSciSources` metrics, which were previously implemented as functions in `ap_verify` (see lsst/ap_verify#63). This change requires that `ip_diffim` depend on `lsst.verify`.

Design note: most of the complexity of the task code comes from `MetricTask` instances not being allowed to assume a particular granularity for their metric. This, in turn, is partly because of Gen 2 (i.e., `MetricsControllerTask`) limitations, but largely because it's not yet known who will be responsible for metrics aggregation.