### PR TITLE
Tickets/DM-18742: speed up DcrModel convergence

### DIFF
--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -307,6 +307,8 @@ class DcrModel:
         exposure : `lsst.afw.image.Exposure`, optional
             The input exposure to build a matched template for.
             May be omitted if all of the metadata is supplied separately
+        order : `int`, optional
+            Interpolation order of the DCR shift.
         visitInfo : `lsst.afw.image.VisitInfo`, optional
             Metadata for the exposure. Ignored if ``exposure`` is set.
         bbox : `lsst.afw.geom.Box2I`, optional

--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -371,14 +371,16 @@ class DcrModel:
         templateExposure : `lsst.afw.image.exposureF`
             The DCR-matched template
         """
+        if bbox is None:
+            bbox = exposure.getBBox()
         templateImage = self.buildMatchedTemplate(exposure=exposure, visitInfo=visitInfo,
                                                   bbox=bbox, wcs=wcs, mask=mask)
         maskedImage = afwImage.MaskedImageF(bbox)
-        maskedImage.image = templateImage
-        maskedImage.mask = self.mask
-        maskedImage.variance = self.variance
+        maskedImage.image = templateImage[bbox]
+        maskedImage.mask = self.mask[bbox]
+        maskedImage.variance = self.variance[bbox]
         templateExposure = afwImage.ExposureF(bbox, wcs)
-        templateExposure.setMaskedImage(maskedImage)
+        templateExposure.setMaskedImage(maskedImage[bbox])
         templateExposure.setPsf(self.psf)
         templateExposure.setFilter(self.filter)
         return templateExposure


### PR DESCRIPTION
Add an option that amplifies the differences between DCR model planes to accelerate convergence. With default settings this is only applied within the footprints of detected sources, and only during the iterative forward modeling step of constructing the DcrModel.

Work on this ticket involved in-depth investigation of frequency regularization, and includes some changes to that implementation.