### PR TITLE
Tickets/DM-19660: warp the PSF in image differencing

### DIFF
--- a/tests/test_imagePsfMatch.py
+++ b/tests/test_imagePsfMatch.py
@@ -131,6 +131,7 @@ class PsfMatchTestCases(unittest.TestCase):
         tExp = afwImage.ExposureF(tMi, tWcs)
         sExp = afwImage.ExposureF(sMi, sWcs)
         sExp.setPsf(self.psf)
+        tExp.setPsf(self.psf)
 
         psfMatchAL = ipDiffim.ImagePsfMatchTask(config=self.configAL)
         psfMatchDF = ipDiffim.ImagePsfMatchTask(config=self.configDF)
@@ -158,6 +159,7 @@ class PsfMatchTestCases(unittest.TestCase):
         tExp = afwImage.ExposureF(tMi, tWcs)
         sExp = afwImage.ExposureF(sMi, sWcs)
         sExp.setPsf(self.psf)
+        tExp.setPsf(self.psf)
 
         psfMatchAL = ipDiffim.ImagePsfMatchTask(config=self.configAL)
         resultsAL = psfMatchAL.matchExposures(tExp, sExp,


### PR DESCRIPTION
Warp the templateCoadd PSF for image differencing using the same `WarpedPsf` method that is used to create `coaddTempExp`s for coaddition.