### PR TITLE
DM-19778: Fix bug in DcrModel coordinates

### DIFF
--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -705,9 +705,10 @@ def calculateImageParallacticAngle(visitInfo, wcs):
     cd = wcs.getCdMatrix()
     if wcs.isFlipped:
         cdAngle = (np.arctan2(-cd[0, 1], cd[0, 0]) + np.arctan2(cd[1, 0], cd[1, 1]))/2.
+        rotAngle = (cdAngle + parAngle)*radians
     else:
         cdAngle = (np.arctan2(cd[0, 1], -cd[0, 0]) + np.arctan2(cd[1, 0], cd[1, 1]))/2.
-    rotAngle = (cdAngle + parAngle)*radians
+        rotAngle = -(cdAngle + parAngle)*radians
     return rotAngle
 
 

--- a/tests/test_dcrModel.py
+++ b/tests/test_dcrModel.py
@@ -365,9 +365,9 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
                                         crval=visitInfo.getBoresightRaDec(),
                                         flipX=flip)
                 rotAngle = calculateImageParallacticAngle(visitInfo, wcs)
-                if flip:
+                if ~flip:
                     rotAngle *= -1
-                self.assertAnglesAlmostEqual(cdRotAngle, rotAngle, maxDiff=1e-6*radians)
+                self.assertAnglesAlmostEqual(cdRotAngle, rotAngle)
 
     def testConditionDcrModelNoChange(self):
         """Conditioning should not change the model if it equals the reference.


### PR DESCRIPTION
Also expands the unit tests to cover a wider range of observing conditions, and adds a test that compares the DCR shift calculation to external coordinate transformations.