### PR TITLE
DM-19978: Fix bug in DcrModel coordinates

### DIFF
--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -708,7 +708,7 @@ def calculateImageParallacticAngle(visitInfo, wcs):
         rotAngle = (cdAngle + parAngle)*radians
     else:
         cdAngle = (np.arctan2(cd[0, 1], -cd[0, 0]) + np.arctan2(cd[1, 0], cd[1, 1]))/2.
-        rotAngle = -(cdAngle + parAngle)*radians
+        rotAngle = (cdAngle - parAngle)*radians
     return rotAngle
 
 

--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -705,9 +705,10 @@ def calculateImageParallacticAngle(visitInfo, wcs):
     cd = wcs.getCdMatrix()
     if wcs.isFlipped:
         cdAngle = (np.arctan2(-cd[0, 1], cd[0, 0]) + np.arctan2(cd[1, 0], cd[1, 1]))/2.
+        rotAngle = (cdAngle + parAngle)*radians
     else:
         cdAngle = (np.arctan2(cd[0, 1], -cd[0, 0]) + np.arctan2(cd[1, 0], cd[1, 1]))/2.
-    rotAngle = (cdAngle + parAngle)*radians
+        rotAngle = -(cdAngle + parAngle)*radians
     return rotAngle
 
 

--- a/tests/test_dcrModel.py
+++ b/tests/test_dcrModel.py
@@ -205,7 +205,7 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
                             height=lsstAlt)
         airmass = 1.0/np.sin(elevation.asDegrees())
 
-        time = Time(2000.0, format="jyear", scale="tai")
+        time = Time(2000.0, format="jyear", scale="tt")
         if randomizeTime:
             # Pick a random date and time within a 20-year span
             time += 20*u.year*self.rng.rand()
@@ -361,7 +361,7 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
         visitInfo = self.makeDummyVisitInfo(azimuth, elevation)
         wcs = self.makeDummyWcs(cdRotAngle, pixelScale, crval=visitInfo.getBoresightRaDec())
         rotAngle = calculateImageParallacticAngle(visitInfo, wcs)
-        refAngle = -1.0848040464064805*radians
+        refAngle = -1.0848032636337364*radians
         self.assertAnglesAlmostEqual(refAngle, rotAngle)
 
     def testRotationSouthZero(self):

--- a/tests/test_dcrModel.py
+++ b/tests/test_dcrModel.py
@@ -205,8 +205,7 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
                             height=lsstAlt)
         airmass = 1.0/np.sin(elevation.asDegrees())
 
-        time = Time(2000., format='decimalyear', scale='tai', location=loc)
-        time += 0.5*u.day  # Add half a day since J2000 is defined at noon
+        time = Time(2000.0, format="jyear", scale="tai")
         if randomizeTime:
             # Pick a random date and time within a 20-year span
             time += 20*u.year*self.rng.rand()
@@ -226,8 +225,7 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
                                       altaz_begin=altaz,
                                       observation_type='science',
                                       )
-        makeVisitInfo = MakeRawVisitInfoViaObsInfo()
-        visitInfo = makeVisitInfo.observationInfo2visitInfo(obsInfo=obsInfo)
+        visitInfo = MakeRawVisitInfoViaObsInfo.observationInfo2visitInfo(obsInfo)
         return visitInfo
 
     def testDummyVisitInfo(self):
@@ -313,7 +311,7 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
             x0, y0 = wcs.skyToPixel(afwGeom.SpherePoint(ra0, dec0))
             dcrShifts = calculateDcr(visitInfo, wcs, filterInfo, dcrNumSubfilters)
             refShifts = []
-            # We divide the filter into "subfilters" with with the full wavelength range
+            # We divide the filter into "subfilters" with the full wavelength range
             # divided into equal sub-ranges.
             for wl0, wl1 in wavelengthGenerator(filterInfo, dcrNumSubfilters):
                 # Note that diffRefractAmp can be negative,

--- a/tests/test_dcrModel.py
+++ b/tests/test_dcrModel.py
@@ -365,9 +365,9 @@ class DcrModelTestTask(lsst.utils.tests.TestCase):
                                         crval=visitInfo.getBoresightRaDec(),
                                         flipX=flip)
                 rotAngle = calculateImageParallacticAngle(visitInfo, wcs)
-                if flip:
+                if ~flip:
                     rotAngle *= -1
-                self.assertAnglesAlmostEqual(cdRotAngle, rotAngle, maxDiff=1e-6*radians)
+                self.assertAnglesAlmostEqual(cdRotAngle, rotAngle)
 
     def testConditionDcrModelNoChange(self):
         """Conditioning should not change the model if it equals the reference.


### PR DESCRIPTION
Also expands the unit tests to cover a wider range of observing conditions, and adds a test that compares the DCR shift calculation to external coordinate transformations.

Note this branch was initially pushed as DM-19778, but was deleted because that was the wrong ticket number.