### PR TITLE
DM-21141: ip_diffim breaks with numpy 1.17

### DIFF
--- a/python/lsst/ip/diffim/diffimTools.py
+++ b/python/lsst/ip/diffim/diffimTools.py
@@ -84,8 +84,7 @@ def makePoissonNoiseImage(im):
     noiseIm = im.Factory(im.getBBox())
     noiseArr = noiseIm.getArray()
 
-    with np.errstate(invalid='ignore'):
-        intNoiseArr = rand.poisson(imArr)
+    intNoiseArr = rand.poisson(np.where(np.isfinite(imArr), imArr, 0.0))
 
     noiseArr[:, :] = intNoiseArr.astype(noiseArr.dtype)
     return noiseIm


### PR DESCRIPTION
Sogo Mineo (NAOJ) points out that this change is necessary

> in order for ip_diffim's tests to pass. I think this is
> because I am using numpy 1.17, in which numpy.random
> changed largely. rand.poisson() no longer accepts
> lam >= 9.223372006484772e+18 or lam = nan.