### PR TITLE
DM-21910: Move lsst.verify.gen2tasks.MetricTask to lsst.verify.tasks

### DIFF
--- a/python/lsst/ip/diffim/metrics.py
+++ b/python/lsst/ip/diffim/metrics.py
@@ -30,8 +30,8 @@ import astropy.units as u
 
 from lsst.pipe.base import Struct, PipelineTaskConnections, connectionTypes
 from lsst.verify import Measurement
-from lsst.verify.gen2tasks import MetricTask, register
-from lsst.verify.tasks import MetricComputationError
+from lsst.verify.gen2tasks import register
+from lsst.verify.tasks import MetricTask, MetricComputationError
 
 
 class NumberSciSourcesMetricConnections(


### PR DESCRIPTION
This PR modifies direct subclasses of `MetricTask` to use its new location rather than `gen2tasks`. Must be merged after lsst/verify#60.