### PR TITLE
Tickets/dm 11991 -- Fix relative calibration between images for ZOGY algorithm

### DIFF
--- a/python/lsst/ip/diffim/getTemplate.py
+++ b/python/lsst/ip/diffim/getTemplate.py
@@ -115,6 +115,7 @@ class GetCoaddAsTemplateTask(pipeBase.Task):
         nPatchesFound = 0
         coaddFilter = None
         coaddPsf = None
+        coaddPhotoCalib = None
         for patchInfo in patchList:
             patchSubBBox = patchInfo.getOuterBBox()
             patchSubBBox.clip(coaddBBox)
@@ -171,12 +172,20 @@ class GetCoaddAsTemplateTask(pipeBase.Task):
             if coaddPsf is None and coaddPatch.hasPsf():
                 coaddPsf = coaddPatch.getPsf()
 
+            # Retrieve the calibration for this coadd tract, if not already retrieved
+            if coaddPhotoCalib is None:
+                coaddPhotoCalib = coaddPatch.getPhotoCalib()
+
         if nPatchesFound == 0:
             raise RuntimeError("No patches found!")
 
         if coaddPsf is None:
             raise RuntimeError("No coadd Psf found!")
 
+        if coaddPhotoCalib is None:
+            raise RuntimeError("No coadd PhotoCalib found!")
+
+        coaddExposure.setPhotoCalib(coaddPhotoCalib)
         coaddExposure.setPsf(coaddPsf)
         coaddExposure.setFilter(coaddFilter)
         return pipeBase.Struct(exposure=coaddExposure,

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -100,7 +100,7 @@ class ZogyConfig(pexConfig.Config):
 
     scaleByCalibration = pexConfig.Field(
         dtype=bool,
-        default=True,
+        default=False,
         doc="Compute the flux normalization scaling based on the image calibration.  This overrides 'templateFluxScaling' and 'scienceFluxScaling'.",
     )
 

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -304,8 +304,17 @@ class ZogyTask(pipeBase.Task):
         if self.config.scaleByCalibration:
             calib_template = self.template.getPhotoCalib()
             calib_science = self.science.getPhotoCalib()
-            self.Fr = 1/calib_template.getCalibrationMean()
-            self.Fn = 1/calib_science.getCalibrationMean()
+            if calib_template is None:
+                self.log.warning("No calibration information available for template image.")
+            if calib_science is None:
+                self.log.warning("No calibration information available for science image.")
+            if calib_template is None or calib_science is None:
+                self.log.warning("Due to lack of calibration information, "
+                                 "reverting to templateFluxScaling and scienceFluxScaling.")
+            else:
+                self.Fr = 1/calib_template.getCalibrationMean()
+                self.Fn = 1/calib_science.getCalibrationMean()
+
             self.log.info("Setting template image scaling to Fr=%f" % self.Fr)
             self.log.info("Setting science  image scaling to Fn=%f" % self.Fn)
 

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -100,7 +100,7 @@ class ZogyConfig(pexConfig.Config):
 
     scaleByCalibration = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc="Compute the flux normalization scaling based on the image calibration."
         "This overrides 'templateFluxScaling' and 'scienceFluxScaling'."
     )

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -176,7 +176,7 @@ class ZogyTask(pipeBase.Task):
             Template exposure ("Reference image" in ZOGY (2016)).
         scienceExposure : `lsst.afw.image.Exposure`
             Science exposure ("New image" in ZOGY (2016)). Must have already been
-            registered and photmetrically matched to template.
+            registered and photometrically matched to template.
         sig1 : `float`
             (Optional) sqrt(variance) of `templateExposure`. If `None`, it is
             computed from the sqrt(mean) of the `templateExposure` variance image.

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -98,6 +98,12 @@ class ZogyConfig(pexConfig.Config):
         doc="Science flux scaling factor (Fn in ZOGY paper)"
     )
 
+    scaleByCalibration = pexConfig.Field(
+        dtype=bool,
+        default=True,
+        doc="Compute the flux normalization scaling based on the image calibration.  This overrides 'templateFluxScaling' and 'scienceFluxScaling'.",
+    )
+
     doTrimKernels = pexConfig.Field(
         dtype=bool,
         default=False,
@@ -290,8 +296,18 @@ class ZogyTask(pipeBase.Task):
             _subtractImageMean(self.template)
             _subtractImageMean(self.science)
 
+        # Define the normalization of each image from the config
         self.Fr = self.config.templateFluxScaling  # default is 1
         self.Fn = self.config.scienceFluxScaling  # default is 1
+        # If 'scaleByCalibration' is True then these norms are overwritten
+        if self.config.scaleByCalibration:
+            calib_template = self.template.getPhotoCalib()
+            calib_science = self.science.getPhotoCalib()
+            self.Fr = 1/calib_template.getCalibrationMean()
+            self.Fn = 1/calib_science.getCalibrationMean()
+            self.log.info("Setting template image scaling to Fr=%f" % self.Fr)
+            self.log.info("Setting science  image scaling to Fn=%f" % self.Fn)
+
         self.padSize = self.config.padSize  # default is 7
 
     def _computeVarianceMean(self, exposure):

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -101,7 +101,8 @@ class ZogyConfig(pexConfig.Config):
     scaleByCalibration = pexConfig.Field(
         dtype=bool,
         default=False,
-        doc="Compute the flux normalization scaling based on the image calibration.  This overrides 'templateFluxScaling' and 'scienceFluxScaling'.",
+        doc="Compute the flux normalization scaling based on the image calibration."
+        "This overrides 'templateFluxScaling' and 'scienceFluxScaling'."
     )
 
     doTrimKernels = pexConfig.Field(

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -315,8 +315,8 @@ class ZogyTask(pipeBase.Task):
                 self.Fr = 1/calib_template.getCalibrationMean()
                 self.Fn = 1/calib_science.getCalibrationMean()
 
-            self.log.info("Setting template image scaling to Fr=%f" % self.Fr)
-            self.log.info("Setting science  image scaling to Fn=%f" % self.Fn)
+        self.log.info("Setting template image scaling to Fr=%f" % self.Fr)
+        self.log.info("Setting science  image scaling to Fn=%f" % self.Fn)
 
         self.padSize = self.config.padSize  # default is 7
 


### PR DESCRIPTION
Sets the ZOGY Fn, Fr normalizations based on the photometric calibration of each image with new `scaleByCalibration` option in `ZogyTask` config.  Option is set to `True` by default.