### PR TITLE
one pixel shift

### DIFF
--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -346,7 +346,7 @@ class ZogyTask(pipeBase.Task):
             The padded copy of the input `psf`.
         """
         newArr = np.zeros(size)
-        # The center of the PSF sould be placed in the center-right. 
+        # The center of the PSF sould be placed in the center-right.
         offset = [size[0]//2 - psf.shape[0]//2, size[1]//2 - psf.shape[1]//2]
         tmp = newArr[offset[0]:(psf.shape[0] + offset[0]), offset[1]:(psf.shape[1] + offset[1])]
         tmp[:, :] = psf

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -346,7 +346,8 @@ class ZogyTask(pipeBase.Task):
             The padded copy of the input `psf`.
         """
         newArr = np.zeros(size)
-        offset = [size[0]//2 - psf.shape[0]//2 - 1, size[1]//2 - psf.shape[1]//2 - 1]
+        # The center of the PSF sould be placed in the center-right. 
+        offset = [size[0]//2 - psf.shape[0]//2, size[1]//2 - psf.shape[1]//2]
         tmp = newArr[offset[0]:(psf.shape[0] + offset[0]), offset[1]:(psf.shape[1] + offset[1])]
         tmp[:, :] = psf
         return newArr

--- a/tests/test_pixelOffset.py
+++ b/tests/test_pixelOffset.py
@@ -3,14 +3,13 @@ import numpy as np
 
 import lsst.afw.image as afwImage
 import lsst.meas.algorithms as measAlg
-import lsst.geom as geom
 from lsst.ip.diffim.zogy import ZogyTask, ZogyConfig
 
 
 class PixelOffsetTest(unittest.TestCase):
     """A test case for the pixel offset.
     """
-    
+
     @staticmethod
     def _makeImage(w, h, psfsize, psfsig, set_peak=False):
         """Make fake images for testing. If set_peak=True, the
@@ -20,7 +19,7 @@ class PixelOffsetTest(unittest.TestCase):
         image = afwImage.MaskedImageF(w, h)
         image.set(0)
         array = image.getImage().getArray()
-        if set_peak == True:
+        if set_peak:
             # set the peak value
             array[300][300] = 1000
         var = image.getVariance()
@@ -31,7 +30,7 @@ class PixelOffsetTest(unittest.TestCase):
         exp = afwImage.makeExposure(image)
         exp.setPsf(psf)
         return exp
-    
+
     @staticmethod
     def _find_max(data):
         """ Find the maximum position of the data.
@@ -43,7 +42,7 @@ class PixelOffsetTest(unittest.TestCase):
         """
         self.imrex = PixelOffsetTest._makeImage(2000, 4000, 17, 1, set_peak=False)
         self.imnex = PixelOffsetTest._makeImage(2000, 4000, 17, 2, set_peak=True)
-        
+
     def testPixelOffset(self):
         """ Test whether the peak position is at [300][300].
         """
@@ -52,5 +51,5 @@ class PixelOffsetTest(unittest.TestCase):
         task = ZogyTask(templateExposure=self.imrex, scienceExposure=self.imnex, config=config)
         D_F = task.computeDiffim(inImageSpace=False)
         max_loc = PixelOffsetTest._find_max(D_F.D.image.array)
-    
+
         self.assertEqual(max_loc, (300, 300))

--- a/tests/test_pixelOffset.py
+++ b/tests/test_pixelOffset.py
@@ -10,20 +10,23 @@ from lsst.ip.diffim.zogy import ZogyTask, ZogyConfig
 class PixelOffsetTest(unittest.TestCase):
     """A test case for the pixel offset.
     """
+    
     @staticmethod
-    def _makeImage(w, h, psfsig, set_peak=False):
+    def _makeImage(w, h, psfsize, psfsig, set_peak=False):
+        """Make fake images for testing. If set_peak=True, the
+        image would have a peak at [50][50].
+        """
         # Make image
         image = afwImage.MaskedImageF(w, h)
         image.set(0)
         array = image.getImage().getArray()
         if set_peak == True:
             # set the peak value
-            array[50][50] = 1000
+            array[300][300] = 1000
         var = image.getVariance()
         var.set(1.0)
         # Make PSF
-        psfSize = 17
-        psf = measAlg.DoubleGaussianPsf(psfSize, psfSize, psfsig, psfsig, 0.)
+        psf = measAlg.DoubleGaussianPsf(psfsize, psfsize, psfsig, psfsig, 0.)
         # Make exposure
         exp = afwImage.makeExposure(image)
         exp.setPsf(psf)
@@ -31,17 +34,23 @@ class PixelOffsetTest(unittest.TestCase):
     
     @staticmethod
     def _find_max(data):
+        """ Find the maximum position of the data.
+        """
         return np.unravel_index(np.argmax(data), data.shape)
 
     def _setUpImages(self):
-        self.imrex = PixelOffsetTest._makeImage(100, 100, 1, set_peak=False)
-        self.imnex = PixelOffsetTest._makeImage(100, 100, 2, set_peak=True)
+        """ Setup test images.
+        """
+        self.imrex = PixelOffsetTest._makeImage(2000, 4000, 17, 1, set_peak=False)
+        self.imnex = PixelOffsetTest._makeImage(2000, 4000, 17, 2, set_peak=True)
         
     def testPixelOffset(self):
+        """ Test whether the peak position is at [300][300].
+        """
         self._setUpImages()
         config = ZogyConfig()
         task = ZogyTask(templateExposure=self.imrex, scienceExposure=self.imnex, config=config)
         D_F = task.computeDiffim(inImageSpace=False)
         max_loc = PixelOffsetTest._find_max(D_F.D.image.array)
     
-        self.assertEqual(max_loc, (50, 50))
+        self.assertEqual(max_loc, (300, 300))

--- a/tests/test_pixelOffset.py
+++ b/tests/test_pixelOffset.py
@@ -12,8 +12,8 @@ class PixelOffsetTest(unittest.TestCase):
 
     @staticmethod
     def _makeImage(w, h, psfsize, psfsig, set_peak=False):
-        """Make fake images for testing. If set_peak=True, the
-        image would have a peak at [50][50].
+        """Make fake images for testing. If set_peak is True, the
+        image would have a peak at [300][300].
         """
         # Make image
         image = afwImage.MaskedImageF(w, h)

--- a/tests/test_pixelOffset.py
+++ b/tests/test_pixelOffset.py
@@ -1,0 +1,47 @@
+import unittest
+import numpy as np
+
+import lsst.afw.image as afwImage
+import lsst.meas.algorithms as measAlg
+import lsst.geom as geom
+from lsst.ip.diffim.zogy import ZogyTask, ZogyConfig
+
+
+class PixelOffsetTest(unittest.TestCase):
+    """A test case for the pixel offset.
+    """
+    @staticmethod
+    def _makeImage(w, h, psfsig, set_peak=False):
+        # Make image
+        image = afwImage.MaskedImageF(w, h)
+        image.set(0)
+        array = image.getImage().getArray()
+        if set_peak == True:
+            # set the peak value
+            array[50][50] = 1000
+        var = image.getVariance()
+        var.set(1.0)
+        # Make PSF
+        psfSize = 17
+        psf = measAlg.DoubleGaussianPsf(psfSize, psfSize, psfsig, psfsig, 0.)
+        # Make exposure
+        exp = afwImage.makeExposure(image)
+        exp.setPsf(psf)
+        return exp
+    
+    @staticmethod
+    def _find_max(data):
+        return np.unravel_index(np.argmax(data), data.shape)
+
+    def _setUpImages(self):
+        self.imrex = PixelOffsetTest._makeImage(100, 100, 1, set_peak=False)
+        self.imnex = PixelOffsetTest._makeImage(100, 100, 2, set_peak=True)
+        
+    def testPixelOffset(self):
+        self._setUpImages()
+        config = ZogyConfig()
+        task = ZogyTask(templateExposure=self.imrex, scienceExposure=self.imnex, config=config)
+        D_F = task.computeDiffim(inImageSpace=False)
+        max_loc = PixelOffsetTest._find_max(D_F.D.image.array)
+    
+        self.assertEqual(max_loc, (50, 50))


### PR DESCRIPTION
1. Fix the one pixel offset bug.
When padding a PSF with (odd, odd) dimension to (even, even) dimension, the center of the PSF should be placed to the center-right of the array. Otherwise the peak value could be shifted to the end of the array after applying np.fft.fftshift(e.g. Correct padding: [0,0,1,2,3,2,1,0] -> [3,2,1,0,0,0,1,2], Incorrect padding: [0,1,2,3,2,1,0,0] - > [2,1,0,0, 0,1,2,3]). This corresponds to a one pixel offset since the np.fft.fft assume the first component of the array as the origin.
2. Add a test file for checking the pixel offset of the ZOGY D image. 