### PR TITLE
DM-23836: Correct the variance of DCR matched templates

### DIFF
--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -395,6 +395,9 @@ class DcrModel:
         maskedImage.image = templateImage[bbox]
         maskedImage.mask = self.mask[bbox]
         maskedImage.variance = self.variance[bbox]
+        # The variance of the stacked image will be `dcrNumSubfilters`
+        # times the variance of the individual subfilters.
+        maskedImage.variance *= self.dcrNumSubfilters
         templateExposure = afwImage.ExposureF(bbox, wcs)
         templateExposure.setMaskedImage(maskedImage[bbox])
         templateExposure.setPsf(self.psf)


### PR DESCRIPTION
The bug was that the variance plane for the subfilters was divided by the number of subfilters, but when the matched exposure was created the variance was set equal to the variance plane of a subfilter. The fix is to multiply the final variance by the number of subfilters so that the original variance is recovered (and we still have the correct variance for the subfilters).