### PR TITLE
DM-23651: ap_pipe calls some deprecated things

### DIFF
--- a/python/lsst/ip/diffim/imageDecorrelation.py
+++ b/python/lsst/ip/diffim/imageDecorrelation.py
@@ -418,8 +418,7 @@ class DecorrelateALKernelTask(pipeBase.Task):
         kernelImg.getArray()[:, :] = kernel
         kern = afwMath.FixedKernel(kernelImg)
         maxloc = np.unravel_index(np.argmax(kernel), kernel.shape)
-        kern.setCtrX(maxloc[0])
-        kern.setCtrY(maxloc[1])
+        kern.setCtr(geom.Point2I(maxloc))
         outExp = exposure.clone()  # Do this to keep WCS, PSF, masks, etc.
         convCntrl = afwMath.ConvolutionControl(False, True, 0)
         afwMath.convolve(outExp.getMaskedImage(), exposure.getMaskedImage(), kern, convCntrl)

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -524,8 +524,7 @@ class ZogyTask(pipeBase.Task):
         kern = afwMath.FixedKernel(kernelImg)
         if recenterKernel:
             maxloc = np.unravel_index(np.argmax(kernel), kernel.shape)
-            kern.setCtrX(maxloc[0])
-            kern.setCtrY(maxloc[1])
+            kern.setCtr(geom.Point2I(maxloc))
         outExp = exposure.clone()  # Do this to keep WCS, PSF, masks, etc.
         convCntrl = afwMath.ConvolutionControl(doNormalize=False, doCopyEdge=False,
                                                maxInterpolationDistance=0)


### PR DESCRIPTION
This PR replaces calls to `Kernel.getCtrX` and `getCtrY` with `getCtr`, and calls to `setCtrX` and `setCtrY` with `setCtr`.