### PR TITLE
DM-28442 Fix variance plane calculation scaling in non-normalized matching kernel case

### DIFF
--- a/python/lsst/ip/diffim/imagePsfMatch.py
+++ b/python/lsst/ip/diffim/imagePsfMatch.py
@@ -637,6 +637,10 @@ class ImagePsfMatchTask(PsfMatchTask):
         )
 
         subtractedExposure = afwImage.ExposureF(scienceExposure, True)
+        # Note, the decorrelation afterburner re-calculates the variance plane
+        # from the variance planes of the original exposures.
+        # That recalculation code must be in accordance with the
+        # photometric level set here in ``subtractedMaskedImage``.
         if convolveTemplate:
             subtractedMaskedImage = subtractedExposure.getMaskedImage()
             subtractedMaskedImage -= results.matchedExposure.getMaskedImage()


### PR DESCRIPTION
 * Add templateMatched to ImageDecorrelation and add variance scaling in science convolution mode.
 * Add the new option to pass on in the DecorrelateALSpatialTask mapper layer.