### PR TITLE
DM-26372: Units wrong in deepDiff_diaSrc catalog

### DIFF
--- a/python/lsst/ip/diffim/dipoleFitTask.py
+++ b/python/lsst/ip/diffim/dipoleFitTask.py
@@ -995,7 +995,7 @@ class DipoleFitPlugin(measBase.SingleFramePlugin):
             setattr(self, ''.join((pos_neg, 'FluxKey')), key)
 
             key = schema.addField(
-                schema.join(name, pos_neg, "instFluxErr"), type=float, units="pixel",
+                schema.join(name, pos_neg, "instFluxErr"), type=float, units="count",
                 doc="1-sigma uncertainty for {0} dipole flux".format(pos_neg))
             setattr(self, ''.join((pos_neg, 'FluxErrKey')), key)
 


### PR DESCRIPTION
This PR fixes instFluxErr units, which were incorrectly set as pixel instead of count.