### PR TITLE
DM-27031: Use primary flag in source count metrics

### DIFF
--- a/python/lsst/ip/diffim/metrics.py
+++ b/python/lsst/ip/diffim/metrics.py
@@ -62,8 +62,9 @@ class NumberSciSourcesMetricTask(MetricTask):
 
     Notes
     -----
-    The task excludes any sky sources in the catalog, but it does not require
-    that the catalog include a ``sky_sources`` column.
+    The task excludes any non-primary sources in the catalog, but it does
+    not require that the catalog include a ``detect_isPrimary`` or
+    ``sky_sources`` column.
     """
     _DefaultName = "numSciSources"
     ConfigClass = NumberSciSourcesMetricConfig
@@ -128,8 +129,9 @@ class FractionDiaSourcesToSciSourcesMetricTask(MetricTask):
 
     Notes
     -----
-    The task excludes any sky sources in the direct source catalog, but it
-    does not require that either catalog include a ``sky_sources`` column.
+    The task excludes any non-primary sources in the catalog, but it does
+    not require that the catalog include a ``detect_isPrimary`` or
+    ``sky_sources`` column.
     """
     _DefaultName = "fracDiaSourcesToSciSources"
     ConfigClass = FractionDiaSourcesToSciSourcesMetricConfig
@@ -171,8 +173,10 @@ class FractionDiaSourcesToSciSourcesMetricTask(MetricTask):
 def _countRealSources(catalog):
     """Return the number of valid sources in a catalog.
 
-    At present, this definition excludes sky sources. If a catalog does not
-    have a ``sky_source`` flag, all sources are assumed to be non-sky.
+    At present, this definition includes only primary sources. If a catalog
+    does not have a ``detect_isPrimary`` flag, this function counts non-sky
+    sources. If it does not have a ``sky_source`` flag, either, all sources
+    are counted.
 
     Parameters
     ----------
@@ -184,7 +188,11 @@ def _countRealSources(catalog):
     count : `int`
         The number of sources that satisfy the criteria.
     """
-    if "sky_source" in catalog.schema:
+    # E712 is not applicable, because afw.table.SourceRecord.ColumnView
+    # is not a bool.
+    if "detect_isPrimary" in catalog.schema:
+        return np.count_nonzero(catalog["detect_isPrimary"] == True)  # noqa: E712
+    elif "sky_source" in catalog.schema:
         return np.count_nonzero(catalog["sky_source"] == False)  # noqa: E712
     else:
         return len(catalog)

--- a/python/lsst/ip/diffim/metrics.py
+++ b/python/lsst/ip/diffim/metrics.py
@@ -157,7 +157,7 @@ class FractionDiaSourcesToSciSourcesMetricTask(MetricTask):
             nSciSources = _countRealSources(sciSources)
             nDiaSources = _countRealSources(diaSources)
             metricName = self.config.metricName
-            if nSciSources <= 0.0:
+            if nSciSources <= 0:
                 raise MetricComputationError(
                     "No science sources found; ratio of DIASources to science sources ill-defined.")
             else:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -22,6 +22,7 @@
 import unittest
 
 import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 from lsst.afw.table import SourceCatalog
 import lsst.utils.tests
@@ -76,7 +77,7 @@ class TestNumSciSources(MetricTaskTestCase):
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ip_diffim.numSciSources"))
-        self.assertEqual(meas.quantity, len(catalog) * u.count)
+        assert_quantity_allclose(meas.quantity, len(catalog) * u.count)
 
     def testEmptyCatalog(self):
         catalog = _makeDummyCatalog(0)
@@ -85,7 +86,7 @@ class TestNumSciSources(MetricTaskTestCase):
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ip_diffim.numSciSources"))
-        self.assertEqual(meas.quantity, 0 * u.count)
+        assert_quantity_allclose(meas.quantity, 0 * u.count)
 
     def testSkySources(self):
         catalog = _makeDummyCatalog(3, skyFlag=True)
@@ -94,7 +95,7 @@ class TestNumSciSources(MetricTaskTestCase):
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ip_diffim.numSciSources"))
-        self.assertEqual(meas.quantity, (len(catalog) - 1) * u.count)
+        assert_quantity_allclose(meas.quantity, (len(catalog) - 1) * u.count)
 
     def testMissingData(self):
         result = self.task.run(None)
@@ -117,7 +118,7 @@ class TestFractionDiaSources(MetricTaskTestCase):
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ip_diffim.fracDiaSourcesToSciSources"))
-        self.assertEqual(meas.quantity, len(diaCatalog) / len(sciCatalog) * u.dimensionless_unscaled)
+        assert_quantity_allclose(meas.quantity, len(diaCatalog) / len(sciCatalog) * u.dimensionless_unscaled)
 
     def testEmptyDiaCatalog(self):
         sciCatalog = _makeDummyCatalog(5)
@@ -127,7 +128,7 @@ class TestFractionDiaSources(MetricTaskTestCase):
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ip_diffim.fracDiaSourcesToSciSources"))
-        self.assertEqual(meas.quantity, 0.0 * u.dimensionless_unscaled)
+        assert_quantity_allclose(meas.quantity, 0.0 * u.dimensionless_unscaled)
 
     def testEmptySciCatalog(self):
         sciCatalog = _makeDummyCatalog(0)
@@ -161,7 +162,8 @@ class TestFractionDiaSources(MetricTaskTestCase):
         meas = result.measurement
 
         self.assertEqual(meas.metric_name, Name(metric="ip_diffim.fracDiaSourcesToSciSources"))
-        self.assertEqual(meas.quantity, len(diaCatalog) / (len(sciCatalog) - 1) * u.dimensionless_unscaled)
+        assert_quantity_allclose(meas.quantity,
+                                 len(diaCatalog) / (len(sciCatalog) - 1) * u.dimensionless_unscaled)
 
 
 # Hack around unittest's hacky test setup system


### PR DESCRIPTION
This PR modifies the metrics that count direct-imaging sources to ignore any sources that don't have the `detect_isPrimary` set (if available).