### PR TITLE
DM-29522 Add spatially varying zogy

### DIFF
--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -22,8 +22,11 @@
 
 import numpy as np
 
+from lsst.geom import Box2I, Point2I, Extent2I
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
+from lsst.afw.image import ImageOrigin
+import lsst.afw.table as afwTable
 import lsst.afw.math as afwMath
 import lsst.meas.algorithms as measAlg
 import lsst.pipe.base as pipeBase
@@ -105,6 +108,17 @@ class ZogyConfig(pexConfig.Config):
         default=0.2,
         doc="Maximum centroid difference allowed between the two exposure PSFs (pixels)."
     )
+    doSpatialGrid = pexConfig.Field(
+        dtype=bool,
+        default=False,
+        doc="Split the exposure and perform matching with the spatially varying PSF."
+    )
+    gridInnerSize = pexConfig.Field(
+        dtype=float,
+        default=8,
+        doc="Approximate useful inner size of the grid cells in units of the "
+        "estimated matching kernel size (doSpatialGrid=True only)."
+    )
 
 
 class ZogyTask(pipeBase.Task):
@@ -138,7 +152,7 @@ class ZogyTask(pipeBase.Task):
         newShape : `tuple` of `int`
             The dimensions of the resulting array. For padding, the resulting array
             must be larger than A in each dimension. For the inverse operation this
-            must be the original, before padding size of the array.
+            must be the original, before padding dimensions of the array.
         useInverse : bool, optional
             Selector of forward, add padding, operation (False)
             or its inverse, crop padding, operation (True).
@@ -193,38 +207,265 @@ class ZogyTask(pipeBase.Task):
         R[-firstHalves[0]:, :secondHalves[1]] = A[:firstHalves[0], -secondHalves[1]:]
         return R
 
-    def computeCommonShape(self, *shapes):
-        """Calculate the common shape for FFT operations.
-
-        Set ``self.freqSpaceShape`` internally.
+    def initializeSubImage(self, fullExp, innerBox, outerBox, noiseMeanVar, useNoise=True):
+        """Initializes a sub image.
 
         Parameters
         ----------
-        shapes : one or more `tuple` of `int`
-            Shapes of the arrays. All must have the same dimensionality.
-            At least one shape must be provided.
-
-        Returns
-        -------
-        None
+        fullExp : `lsst.afw.image.Exposure`
+            The full exposure to cut sub image from.
+        innerBox : `lsst.geom.Box2I`
+            The useful area of the calculation up to the whole bounding box of
+            ``fullExp``. ``fullExp`` must contain this box.
+        outerBox : `lsst.geom.Box2I`
+            The overall cutting area. ``outerBox`` must be at least 1 pixel larger
+            than ``inneBox`` in all directions and may not be fully contained by
+            ``fullExp``.
+        noiseMeanVar : `float` > 0.
+            The noise variance level to initialize variance plane and to generate
+            white noise for the non-overlapping region.
+        useNoise : `bool`, optional
+            If True, generate white noise for non-overlapping region. Otherwise,
+            zero padding will be used in the non-overlapping region.
 
         Notes
         -----
-        For each dimension, gets the smallest even number greater than or equal to
-        `N1+N2-1` where `N1` and `N2` are the two largest values.
-        In case of only one shape given, rounds up to even each dimension value.
+        ``innerBox``, ``outerBox`` must be in the PARENT system of ``fullExp``.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+          - ``subImg``, ``subVarImg`` : `lsst.afw.image.ImageD`
+            The new sub image and its sub variance plane.
+
+        Notes
+        -----
+        Supports the non-grid option when ``innerBox`` equals to the
+        bounding box of ``fullExp``.
         """
-        S = np.array(shapes, dtype=int)
-        if len(shapes) > 2:
-            S.sort(axis=0)
-            S = S[-2:]
-        if len(shapes) > 1:
-            commonShape = np.sum(S, axis=0) - 1
+        fullBox = fullExp.getBBox()
+        subImg = afwImage.ImageD(outerBox, 0)
+        subVarImg = afwImage.ImageD(outerBox, noiseMeanVar)
+        borderBoxes = self.splitBorder(innerBox, outerBox)
+        # Initialize the border region that are not fully within the exposure
+        if useNoise:
+            noiseSig = np.sqrt(noiseMeanVar)
+            for box in borderBoxes:
+                if not fullBox.contains(box):
+                    R = subImg[box].array
+                    R[...] = self.rng.normal(scale=noiseSig, size=R.shape)
+        # Copy data to the fully contained inner region, allowing type conversion
+        subImg[innerBox].array[...] = fullExp.image[innerBox].array
+        subVarImg[innerBox].array[...] = fullExp.variance[innerBox].array
+        # Copy data to border regions that have at least a partial overlap
+        for box in borderBoxes:
+            overlapBox = box.clippedTo(fullBox)
+            if not overlapBox.isEmpty():
+                subImg[overlapBox].array[...] = fullExp.image[overlapBox].array
+                subVarImg[overlapBox].array[...] = fullExp.variance[overlapBox].array
+        return pipeBase.Struct(image=subImg, variance=subVarImg)
+
+    @staticmethod
+    def estimateMatchingKernelSize(psf1, psf2):
+        """Estimate the image space size of the matching kernels.
+
+        Return ten times the larger Gaussian sigma estimate but at least
+        the largest of the original psf dimensions.
+
+        Parameters
+        ----------
+        psf1, psf2 : `lsst.afw.detection.Psf`
+            The PSFs of the two input exposures.
+
+        Returns
+        -------
+        size : `int`
+            Conservative estimate for matching kernel size in pixels.
+            This is the minimum padding around the inner region at each side.
+
+        Notes
+        -----
+        """
+        sig1 = psf1.computeShape().getDeterminantRadius()
+        sig2 = psf2.computeShape().getDeterminantRadius()
+        sig = max(sig1, sig2)
+        psfBBox1 = psf1.computeBBox()
+        psfBBox2 = psf2.computeBBox()
+        return max(10 * sig, psfBBox1.getWidth(), psfBBox1.getHeight(),
+                   psfBBox2.getWidth(), psfBBox2.getHeight())
+
+    @staticmethod
+    def splitBorder(innerBox, outerBox):
+        """Split the border area around the inner box into 8 disjunct boxes.
+
+        Parameters
+        ----------
+        innerBox : `lsst.geom.Box2I`
+            The inner box.
+        outerBox : `lsst.geom.Box2I`
+            The outer box. It must be at least 1 pixel larger in each direction than the inner box.
+
+        Returns
+        -------
+        resultBoxes : `list` of 8 boxes covering the edge around innerBox
+
+        Notes
+        -----
+        The border boxes do not overlap. The border is covered counter clockwise
+        starting from lower left corner.
+
+        Raises
+        ------
+        ValueError : If ``outerBox`` is not larger than ``innerBox``.
+        """
+        innerBox = innerBox.dilatedBy(1)
+        if not outerBox.contains(innerBox):
+            raise ValueError("OuterBox must be larger by at least 1 pixel in all directions")
+
+        # ccw sequence of corners
+        o1, o2, o3, o4 = outerBox.getCorners()
+        i1, i2, i3, i4 = innerBox.getCorners()
+        p1 = Point2I(outerBox.minX, innerBox.minY)
+        p2 = Point2I(innerBox.maxX, outerBox.minY)
+        p3 = Point2I(outerBox.maxX, innerBox.maxY)
+        p4 = Point2I(innerBox.minX, outerBox.maxY)
+
+        # The 8 border boxes ccw starting from lower left
+        pointPairs = ((o1, i1), (i1 + Extent2I(1, 0), p2 + Extent2I(-1, 0)), (o2, i2),
+                      (i2 + Extent2I(0, 1), p3 + Extent2I(0, -1)), (o3, i3),
+                      (i3 + Extent2I(-1, 0), p4 + Extent2I(1, 0)), (o4, i4),
+                      (i4 + Extent2I(0, -1), p1 + Extent2I(0, 1)))
+        return [Box2I(x, y, invert=True) for (x, y) in pointPairs]
+
+    @staticmethod
+    def generateGrid(imageBox, minEdgeDims, innerBoxDims, minTotalDims=None, powerOfTwo=False):
+        """Generate a splitting grid for an image.
+
+        The inner boxes cover the input image without overlap, the edges around the inner boxes do overlap
+        and go beyond the image at the image edges.
+
+        Parameters
+        ----------
+        imageBox : `lsst.geom.Box2I`
+            Bounding box of the exposure to split.
+        minEdgeDims : `lsst.geom.Extent2I`
+            Minimum edge width in (x,y) directions each side.
+        innerBoxDims : `lsst.geom.Extent2I`
+            Minimum requested inner box dimensions (x,y).
+            The actual dimensions can be larger due to rounding.
+        minTotalDims: `lsst.geom.Extent2I`, optional
+            If provided, minimum total outer dimensions (x,y). The edge will be increased until satisfied.
+        powerOfTwo : `bool`, optional
+            If True, the outer box dimensions should be rounded up to a power of 2
+            by increasing the border size. This is up to 8192, above this size,
+            rounding up is disabled.
+
+        Notes
+        -----
+        Inner box dimensions are chosen to be as uniform as they can, remainder pixels at the edge of the
+        input will be appended to the last column/row boxes.
+
+        See diffimTests/tickets/DM-28928_spatial_grid notebooks for demonstration of this code.
+
+        This method can be used for both PARENT and LOCAL bounding boxes.
+
+        The outerBox dimensions are always even.
+
+        Returns
+        -------
+        boxList : `list` of `lsst.pipe.base.Struct`
+          ``innerBox``, ``outerBox`` : `lsst.geom.Box2I`, inner boxes and overlapping border around them.
+
+        """
+        powersOf2 = np.array([16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192])
+        doubleEdgeDims = minEdgeDims * 2
+        width, height = imageBox.getDimensions()
+        nX = width // innerBoxDims.x  # Round down
+        if nX > 0:
+            innerWidth = width // nX  # Round down
         else:
-            commonShape = S[0]
-        commonShape[commonShape % 2 != 0] += 1
-        self.freqSpaceShape = tuple(commonShape)
-        self.log.info(f"Common frequency space shape {self.freqSpaceShape}")
+            innerWidth = width
+            nX = 1
+        xCorners = np.zeros(nX + 1)
+        xCorners[:-1] = np.arange(nX)*innerWidth + imageBox.minX
+        xCorners[-1] = imageBox.endX
+
+        nY = height // innerBoxDims.y  # Round down
+        if nY > 0:
+            innerHeight = height // nY  # Round down
+        else:
+            innerHeight = height
+            nY = 1
+        yCorners = np.zeros(nY + 1)
+        yCorners[:-1] = np.arange(nY)*innerHeight + imageBox.minY
+        yCorners[-1] = imageBox.endY
+
+        boxes = []
+
+        for i_y in range(nY):
+            for i_x in range(nX):
+                innerBox = Box2I(Point2I(xCorners[i_x], yCorners[i_y]),
+                                 Point2I(xCorners[i_x + 1] - 1, yCorners[i_y + 1] - 1))
+
+                paddedWidth = innerBox.width + doubleEdgeDims.x
+                if minTotalDims is not None and paddedWidth < minTotalDims.width:
+                    paddedWidth = minTotalDims.width
+                if powerOfTwo:
+                    i2x = np.searchsorted(powersOf2, paddedWidth, side='left')
+                    if i2x < len(powersOf2):
+                        paddedWidth = powersOf2[i2x]
+                if paddedWidth % 2 == 1:
+                    paddedWidth += 1  # Ensure total width is even
+
+                totalXedge = paddedWidth - innerBox.width
+
+                paddedHeight = innerBox.height + doubleEdgeDims.y
+                if minTotalDims is not None and paddedHeight < minTotalDims.height:
+                    paddedHeight = minTotalDims.height
+                if powerOfTwo:
+                    i2y = np.searchsorted(powersOf2, paddedHeight, side='left')
+                    if i2y < len(powersOf2):
+                        paddedHeight = powersOf2[i2y]
+                if paddedHeight % 2 == 1:
+                    paddedHeight += 1  # Ensure total height is even
+                totalYedge = paddedHeight - innerBox.height
+                outerBox = Box2I(Point2I(innerBox.minX - totalXedge//2, innerBox.minY - totalYedge//2),
+                                 Extent2I(paddedWidth, paddedHeight))
+                boxes.append(pipeBase.Struct(innerBox=innerBox, outerBox=outerBox))
+        return boxes
+
+    def makeSpatialPsf(self, gridPsfs):
+        """Construct a CoaddPsf based on PSFs from individual sub image solutions.
+
+        Parameters
+        ----------
+        gridPsfs : iterable of `lsst.pipe.base.Struct`
+            Iterable of bounding boxes (``bbox``) and Psf solutions (``psf``).
+
+        Returns
+        -------
+        psf : `lsst.meas.algorithms.CoaddPsf`
+            A psf constructed from the PSFs of the individual subExposures.
+        """
+        schema = afwTable.ExposureTable.makeMinimalSchema()
+        schema.addField("weight", type="D", doc="Coadd weight")
+        mycatalog = afwTable.ExposureCatalog(schema)
+
+        # We're just using the exposure's WCS (assuming that the subExposures'
+        # WCSs are the same, which they better be!).
+        wcsref = self.fullExp1.getWcs()
+        for i, res in enumerate(gridPsfs):
+            record = mycatalog.getTable().makeRecord()
+            record.setPsf(res.psf)
+            record.setWcs(wcsref)
+            record.setBBox(res.bbox)
+            record['weight'] = 1.0
+            record['id'] = i
+            mycatalog.append(record)
+
+        # create the CoaddPsf
+        psf = measAlg.CoaddPsf(mycatalog, wcsref, 'weight')
+        return psf
 
     def padAndFftImage(self, imgArr):
         """Prepare and forward FFT an image array.
@@ -256,6 +497,33 @@ class ZogyTask(pipeBase.Task):
         imgArr = self.padCenterOriginArray(imgArr, self.freqSpaceShape)
         imgArr = np.fft.fft2(imgArr)
         return pipeBase.Struct(imFft=imgArr, filtInf=filtInf, filtNaN=filtNaN)
+
+    def removeNonFinitePixels(self, imgArr):
+        """Replace non-finite pixel values in-place.
+
+        Save the locations of non-finite values for restoration, and replace them
+        with image mean values.
+
+        Parameters
+        ----------
+        imgArr : `numpy.ndarray` of `float`
+            The image array. Non-finite values are replaced in-place in this array.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            - ``filtInf``, ``filtNaN`` : `numpy.ndarray` of `bool`
+                The filter of the pixel values that were inf or nan.
+        """
+        filtInf = np.isinf(imgArr)
+        filtNaN = np.isnan(imgArr)
+        # Masked edge and bad pixels could also be removed here in the same way
+        # in the future
+        imgArr[filtInf] = np.nan
+        imgArr[filtInf | filtNaN] = np.nanmean(imgArr)
+        self.log.debugf("Replacing {} Inf and {} NaN values.",
+                        np.sum(filtInf), np.sum(filtNaN))
+        return pipeBase.Struct(filtInf=filtInf, filtNaN=filtNaN)
 
     def inverseFftAndCropImage(self, imgArr, origSize, filtInf=None, filtNaN=None, dtype=None):
         """Inverse FFT and crop padding from image array.
@@ -306,8 +574,8 @@ class ZogyTask(pipeBase.Task):
         psfImg : `lsst.afw.image.Image`
             Calculated psf image.
         """
-        bbox = exposure.getBBox()
-        cen = bbox.getCenter()
+        pBox = exposure.getBBox()
+        cen = pBox.getCenter()
         psf = exposure.getPsf()
         psfImg = psf.computeKernelImage(cen)  # Centered and normed
         return psfImg
@@ -344,10 +612,13 @@ class ZogyTask(pipeBase.Task):
             raise ValueError("Image mean is NaN.")
 
     def prepareFullExposure(self, exposure1, exposure2, correctBackground=False):
-        """Performs calculations that apply to the full exposures once only in the psf matching.
+        """Performs calculations that apply to the full exposures once only.
 
         Parameters
         ----------
+
+        exposure1, exposure2 : `lsst.afw.image.Exposure`
+            The input exposures. Copies are made for internal calculations.
 
         correctBackground : `bool`, optional
             If True, subtracts sigma-clipped mean of exposures. The algorithm
@@ -359,16 +630,13 @@ class ZogyTask(pipeBase.Task):
 
         Notes
         -----
-        Set a number of instance fields with pre-calculated values. ``psfShape``,
-        ``imgShape`` fields follow the numpy ndarray shape convention i.e. height,
-        width.
+        Set a number of instance fields with pre-calculated values.
 
         Raises
         ------
         ValueError : If photometric calibrations are not available while
             ``config.scaleByCalibration`` equals True.
         """
-
         self.statsControl = afwMath.StatisticsControl()
         self.statsControl.setNumSigmaClip(3.)
         self.statsControl.setNumIter(3)
@@ -377,6 +645,12 @@ class ZogyTask(pipeBase.Task):
 
         exposure1 = exposure1.clone()
         exposure2 = exposure2.clone()
+        # Fallback values if sub exposure variance calculation is problematic
+        sig1 = np.sqrt(self._computeVarianceMean(exposure1))
+        self.fullExpVar1 = sig1*sig1
+        sig2 = np.sqrt(self._computeVarianceMean(exposure2))
+        self.fullExpVar2 = sig2*sig2
+
         # If 'scaleByCalibration' is True then these norms are overwritten
         if self.config.scaleByCalibration:
             calibObj1 = exposure1.getPhotoCalib()
@@ -398,30 +672,22 @@ class ZogyTask(pipeBase.Task):
             self.subtractImageMean(mImg1.image, mImg1.mask, self.statsControl)
             self.subtractImageMean(mImg2.image, mImg2.mask, self.statsControl)
 
-        psfBBox1 = exposure1.getPsf().computeBBox()
-        psfBBox2 = exposure2.getPsf().computeBBox()
-        # Shapes for numpy arrays
-        self.psfShape1 = (psfBBox1.getHeight(), psfBBox1.getWidth())
-        self.psfShape2 = (psfBBox2.getHeight(), psfBBox2.getWidth())
-        self.imgShape = (mImg1.getHeight(), mImg1.getWidth())
-        # We need the calibrated, full size original
-        # MaskedImages for the variance plane calculations
+        # Determine border size
+        self.borderSize = self.estimateMatchingKernelSize(exposure1.getPsf(), exposure2.getPsf())
+        self.log.debugf("Minimum padding border size: {} pixels", self.borderSize)
+        # Remove non-finite values from the images in-place
+        self.filtsImg1 = self.removeNonFinitePixels(mImg1.image.array)
+        self.filtsImg2 = self.removeNonFinitePixels(mImg2.image.array)
+        self.filtsVar1 = self.removeNonFinitePixels(mImg1.variance.array)
+        self.filtsVar2 = self.removeNonFinitePixels(mImg2.variance.array)
+
         exposure1.maskedImage = mImg1
         exposure2.maskedImage = mImg2
-        # TODO DM-25174 : Here we need actually not psfShape but an
-        # estimation of the size of Pd and Ps
-        # worst case scenario a padding of imgShape (? TBC)
-        self.computeCommonShape(self.imgShape, self.psfShape1, self.psfShape2)
 
         self.fullExp1 = exposure1
         self.fullExp2 = exposure2
 
-        self.fftFullIm1 = self.padAndFftImage(mImg1.image.array)
-        self.fftVarPl1 = self.padAndFftImage(mImg1.variance.array)
-        self.fftFullIm2 = self.padAndFftImage(mImg2.image.array)
-        self.fftVarPl2 = self.padAndFftImage(mImg2.variance.array)
-
-    def prepareSubExposure(self, bbox1=None, bbox2=None, psf1=None, psf2=None, sig1=None, sig2=None):
+    def prepareSubExposure(self, localCutout, psf1=None, psf2=None, sig1=None, sig2=None):
         """Perform per-sub exposure preparations.
 
         Parameters
@@ -429,12 +695,10 @@ class ZogyTask(pipeBase.Task):
         sig1, sig2 : `float`, optional
             For debug purposes only, copnsider that the image
             may already be rescaled by the photometric calibration.
-        bbox1, bbox2 : `lsst.geom.Box2I`, optional
-            If specified, the region of the full exposure to use.
-
+        localCutout : `lsst.pipe.base.Struct`
+            - innerBox, outerBox: `lsst.geom.Box2I` LOCAL inner and outer boxes
         psf1, psf2 : `lsst.afw.detection.Psf`, optional
             If specified, use given psf as the sub exposure psf. For debug purposes.
-
         sig1, sig2 : `float`, optional
             If specified, use value as the sub-exposures' background noise sigma value.
 
@@ -442,52 +706,70 @@ class ZogyTask(pipeBase.Task):
         -------
         None
 
-        Notes
-        -----
-        TODO DM-23855: Performing ZOGY on a grid is not yet implemented.
-        Set (replace) a number of instance fields with pre-calculated values
-        about the current sub exposure including the FFT of the psfs.
-
-        Raises
-        ------
-        ValueError: If sub-exposure dimensions do not match.
         """
-        if bbox1 is None:
-            subExposure1 = self.fullExp1.clone()
-        else:
-            subExposure1 = self.fullExp1.Factory(self.exposure1, bbox1)
-        if bbox2 is None:
-            subExposure2 = self.fullExp2.clone()
-        else:
-            subExposure2 = self.fullExp2.Factory(self.exposure2, bbox2)
-
-        if subExposure1.getDimensions() != subExposure2.getDimensions():
-            raise ValueError("Subexposure dimensions do not match.")
-
+        self.log.debugf("Processing LOCAL cell w/ inner box:{}, outer box:{}",
+                        localCutout.innerBox, localCutout.outerBox)
+        # The PARENT origin cutout boxes for the two exposures
+        self.cutBoxes1 = pipeBase.Struct(
+            innerBox=localCutout.innerBox.shiftedBy(Extent2I(self.fullExp1.getXY0())),
+            outerBox=localCutout.outerBox.shiftedBy(Extent2I(self.fullExp1.getXY0())))
+        self.cutBoxes2 = pipeBase.Struct(
+            innerBox=localCutout.innerBox.shiftedBy(Extent2I(self.fullExp2.getXY0())),
+            outerBox=localCutout.outerBox.shiftedBy(Extent2I(self.fullExp2.getXY0())))
+        # The sub-exposure views of the useful inner area of this grid cell
+        innerSubExp1 = self.fullExp1[self.cutBoxes1.innerBox]
+        innerSubExp2 = self.fullExp2[self.cutBoxes2.innerBox]
         if psf1 is None:
-            self.subExpPsf1 = self.computePsfAtCenter(subExposure1)
+            self.subExpPsf1 = self.computePsfAtCenter(innerSubExp1)
         else:
             self.subExpPsf1 = psf1
         if psf2 is None:
-            self.subExpPsf2 = self.computePsfAtCenter(subExposure2)
+            self.subExpPsf2 = self.computePsfAtCenter(innerSubExp2)
         else:
             self.subExpPsf2 = psf2
         self.checkCentroids(self.subExpPsf1.array, self.subExpPsf2.array)
+        psfBBox1 = self.subExpPsf1.getBBox()
+        psfBBox2 = self.subExpPsf2.getBBox()
+        self.psfShape1 = (psfBBox1.getHeight(), psfBBox1.getWidth())
+        self.psfShape2 = (psfBBox2.getHeight(), psfBBox2.getWidth())
         # sig1 and sig2  should not be set externally, just for debug purpose
         if sig1 is None:
-            sig1 = np.sqrt(self._computeVarianceMean(subExposure1))
-        self.subExpVar1 = sig1*sig1
+            sig1 = np.sqrt(self._computeVarianceMean(innerSubExp1))
+        if sig1 > 0.:  # Not zero and not nan
+            self.subExpVar1 = sig1*sig1
+        else:
+            self.subExpVar1 = self.fullExpVar1
         if sig2 is None:
-            sig2 = np.sqrt(self._computeVarianceMean(subExposure2))
-        self.subExpVar2 = sig2*sig2
+            sig2 = np.sqrt(self._computeVarianceMean(innerSubExp2))
+        if sig2 > 0.:  # Not zero and not nan
+            self.subExpVar2 = sig2*sig2
+        else:
+            self.subExpVar2 = self.fullExpVar2
+        # Initialize random number generator to a deterministic state
+        self.rng = np.random.default_rng(seed=np.array([self.subExpVar1]).view(int))
+        self.freqSpaceShape = (localCutout.outerBox.getHeight(), localCutout.outerBox.getWidth())
+
+        self.subImg1 = self.initializeSubImage(
+            self.fullExp1, self.cutBoxes1.innerBox, self.cutBoxes1.outerBox,
+            self.subExpVar1, useNoise=True)
+        self.subImg2 = self.initializeSubImage(
+            self.fullExp2, self.cutBoxes2.innerBox, self.cutBoxes2.outerBox,
+            self.subExpVar2, useNoise=True)
+
+        D = self.padCenterOriginArray(self.subImg1.image.array, self.freqSpaceShape)
+        self.subImgFft1 = np.fft.fft2(D)
+        D = self.padCenterOriginArray(self.subImg1.variance.array, self.freqSpaceShape)
+        self.subVarImgFft1 = np.fft.fft2(D)
+
+        D = self.padCenterOriginArray(self.subImg2.image.array, self.freqSpaceShape)
+        self.subImgFft2 = np.fft.fft2(D)
+        D = self.padCenterOriginArray(self.subImg2.variance.array, self.freqSpaceShape)
+        self.subVarImgFft2 = np.fft.fft2(D)
 
         D = self.padCenterOriginArray(self.subExpPsf1.array, self.freqSpaceShape)
         self.psfFft1 = np.fft.fft2(D)
         D = self.padCenterOriginArray(self.subExpPsf2.array, self.freqSpaceShape)
         self.psfFft2 = np.fft.fft2(D)
-
-        self.subExposure1 = subExposure1
-        self.subExposure2 = subExposure2
 
     @staticmethod
     def pixelSpaceSquare(D):
@@ -620,7 +902,7 @@ class ZogyTask(pipeBase.Task):
 
         Notes
         -----
-        All array inputs and outputs are Fourier-space images with size of
+        All array inputs and outputs are Fourier-space images with shape of
         `self.freqSpaceShape` in this method.
 
         ``varMean1``, ``varMean2`` quantities are part of the noise model and not to be confused
@@ -732,101 +1014,151 @@ class ZogyTask(pipeBase.Task):
         psfNew = measAlg.KernelPsf(afwMath.FixedKernel(psfImg))
         return psfNew
 
-    def makeDiffimSubExposure(self, ftDiff):
-        """Wrap array results into Exposure objects.
+    def pasteSubDiffImg(self, ftDiff, diffExp, scoreExp=None):
+        """Paste sub image results back into result Exposure objects.
 
         Parameters
         ----------
         ftDiff : `lsst.pipe.base.Struct`
             Result struct by `calculateFourierDiffim`.
+        diffExp : `lsst.afw.image.Exposure`
+            The result exposure to paste into the sub image result.
+            Must be dimensions and dtype of ``self.fullExp1``.
+        scoreExp : `lsst.afw.image.Exposure` or `None`
+            The result score exposure to paste into the sub image result.
+            Must be dimensions and dtype of ``self.fullExp1``.
+            If `None`, the score image results are disregarded.
 
         Returns
         -------
-        resultName : `lsst.pipe.base.Struct`
-            - ``diffSubExp`` : `lsst.afw.image.Exposure`
-                The difference (sub)exposure. The exposure is calibrated
-                in its pixel values, and has a constant `PhotoCalib` object of 1.
-            - ``scoreSubExp`` : `lsst.afw.image.Exposure` or `None`
-                The score (sub)exposure if it was calculated.
+        None
+
+        Notes
+        -----
+        The PSF of the score image is just to make the score image resemble a
+        regular exposure and to study the algorithm performance.
+
+        Add an entry to the ``self.gridPsfs`` list.
+
+        gridPsfs : `list` of `lsst.pipe.base.Struct`
+            - ``bbox`` : `lsst.geom.Box2I`
+                The inner region of the grid cell.
+            - ``Pd`` :  `lsst.meas.algorithms.KernelPsf`
+                The diffim PSF in this cell.
+            - ``Ps`` :  `lsst.meas.algorithms.KernelPsf` or `None`
+                The score image PSF in this cell or `None` if the score
+                image was not calculated.
         """
         D = self.inverseFftAndCropImage(
-            ftDiff.D, self.imgShape, np.logical_or(self.fftFullIm1.filtInf, self.fftFullIm2.filtInf),
-            np.logical_or(self.fftFullIm1.filtNaN, self.fftFullIm2.filtNaN),
-            dtype=self.subExposure1.image.dtype)
+            ftDiff.D, self.freqSpaceShape, dtype=self.fullExp1.image.dtype)
         varPlaneD = self.inverseFftAndCropImage(
-            ftDiff.varPlaneD, self.imgShape, np.logical_or(self.fftVarPl1.filtInf, self.fftVarPl2.filtInf),
-            np.logical_or(self.fftVarPl1.filtNaN, self.fftVarPl2.filtNaN),
-            dtype=self.subExposure1.variance.dtype)
+            ftDiff.varPlaneD, self.freqSpaceShape, dtype=self.fullExp1.variance.dtype)
         Pd = self.inverseFftAndCropImage(
             ftDiff.Pd, self.psfShape1, dtype=self.subExpPsf1.dtype)
         sumPd = np.sum(Pd)
         # If this is smaller than 1. it is an indicator that it does not fit its original dimensions
-        self.log.info(f"Pd sum before normalization: {sumPd:.3f}")
+        self.log.infof("Pd sum before normalization: {:.3f}", sumPd)
         Pd /= sumPd
+        # Convert Pd into a Psf object
+        Pd = self.makeKernelPsfFromArray(Pd)
 
-        diffSubExposure = self.subExposure1.clone()
-        # Indices of the subexposure bbox in the full image array
-        bbox = self.subExposure1.getBBox()
-        xy0 = self.fullExp1.getXY0()
-        imgD = afwImage.Image(D, deep=False, xy0=xy0, dtype=self.subExposure1.image.dtype)
-        diffSubExposure.image = imgD[bbox]
+        xy0 = self.cutBoxes1.outerBox.getMin()
+        # D is already converted back to dtype of fullExp1
+        # Encapsulate D simply into an afwImage.Image for correct inner-outer box handling
+        imgD = afwImage.Image(D, deep=False, xy0=xy0, dtype=self.fullExp1.image.dtype)
+        diffExp.image[self.cutBoxes1.innerBox] = imgD[self.cutBoxes1.innerBox]
         imgVarPlaneD = afwImage.Image(varPlaneD, deep=False, xy0=xy0,
-                                      dtype=self.subExposure1.variance.dtype)
-        diffSubExposure.variance = imgVarPlaneD[bbox]
-        diffSubExposure.mask = self.calculateMaskPlane(self.subExposure1.mask, self.subExposure2.mask)
+                                      dtype=self.fullExp1.variance.dtype)
+        diffExp.variance[self.cutBoxes1.innerBox] = imgVarPlaneD[self.cutBoxes1.innerBox]
+        diffExp.mask[self.cutBoxes1.innerBox] = self.calculateMaskPlane(
+            self.fullExp1.mask[self.cutBoxes1.innerBox], self.fullExp2.mask[self.cutBoxes2.innerBox])
 
-        # Calibrate the image; subexposures must be on the same photometric scale
-        diffSubExposure.maskedImage /= ftDiff.Fd
-        # Now the subExposure calibration is 1. everywhere
-        calibOne = afwImage.PhotoCalib(1.)
-        diffSubExposure.setPhotoCalib(calibOne)
-        # Set the PSF of this subExposure
-        diffSubExposure.setPsf(self.makeKernelPsfFromArray(Pd))
+        # Calibrate the image; subimages on the grid must be on the same photometric scale
+        # Now the calibration object will be 1. everywhere
+        diffExp.maskedImage[self.cutBoxes1.innerBox] /= ftDiff.Fd
 
-        if ftDiff.S is not None:
+        if ftDiff.S is not None and scoreExp is not None:
             S = self.inverseFftAndCropImage(
-                ftDiff.S, self.imgShape, dtype=self.subExposure1.image.dtype)
+                ftDiff.S, self.freqSpaceShape, dtype=self.fullExp1.image.dtype)
             varPlaneS = self.inverseFftAndCropImage(
-                ftDiff.varPlaneS, self.imgShape, dtype=self.subExposure1.variance.dtype)
+                ftDiff.varPlaneS, self.freqSpaceShape, dtype=self.fullExp1.variance.dtype)
 
-            # There is no detection where the image or its variance was not finite
-            flt = (self.fftFullIm1.filtInf | self.fftFullIm2.filtInf
-                   | self.fftFullIm1.filtNaN | self.fftFullIm2.filtNaN
-                   | self.fftVarPl1.filtInf | self.fftVarPl2.filtInf
-                   | self.fftVarPl1.filtNaN | self.fftVarPl2.filtNaN)
-            # Ensure that no division by 0 occurs in S/sigma(S).
-            # S is set to be always finite, 0 where pixels non-finite
-            tiny = np.finfo(varPlaneS.dtype).tiny * 100
-            flt = np.logical_or(flt, varPlaneS < tiny)
-            # tiny is not safe, becomes 0 in case of conversion to single precision
-            # set variance to 1, indicating that zero is in units of "sigmas" already
-            varPlaneS[flt] = 1
-            S[flt] = 0
-
-            imgS = afwImage.Image(S, deep=False, xy0=xy0, dtype=self.subExposure1.image.dtype)
+            imgS = afwImage.Image(S, deep=False, xy0=xy0, dtype=self.fullExp1.image.dtype)
             imgVarPlaneS = afwImage.Image(varPlaneS, deep=False, xy0=xy0,
-                                          dtype=self.subExposure1.variance.dtype)
-            imgS = imgS[bbox]
-            imgVarPlaneS = imgVarPlaneS[bbox]
+                                          dtype=self.fullExp1.variance.dtype)
+            scoreExp.image[self.cutBoxes1.innerBox] = imgS[self.cutBoxes1.innerBox]
+            scoreExp.variance[self.cutBoxes1.innerBox] = imgVarPlaneS[self.cutBoxes1.innerBox]
 
             # PSF of S
             Ps = self.inverseFftAndCropImage(ftDiff.Ps, self.psfShape1, dtype=self.subExpPsf1.dtype)
             sumPs = np.sum(Ps)
-            self.log.info(f"Ps sum before normalization: {sumPs:.3f}")
+            self.log.infof("Ps sum before normalization: {:.3f}", sumPs)
             Ps /= sumPs
 
             # TODO DM-23855 : Additional score image corrections may be done here
 
-            scoreSubExposure = self.subExposure1.clone()
-            scoreSubExposure.image = imgS
-            scoreSubExposure.variance = imgVarPlaneS
-            scoreSubExposure.mask = diffSubExposure.mask
-            scoreSubExposure.setPhotoCalib(None)
-            scoreSubExposure.setPsf(self.makeKernelPsfFromArray(Ps))
+            scoreExp.mask[self.cutBoxes1.innerBox] = diffExp.mask[self.cutBoxes1.innerBox]
+            # Convert Ps into a Psf object
+            Ps = self.makeKernelPsfFromArray(Ps)
         else:
-            scoreSubExposure = None
+            Ps = None
+        self.gridPsfs.append(pipeBase.Struct(bbox=self.cutBoxes1.innerBox, Pd=Pd, Ps=Ps))
 
-        return pipeBase.Struct(diffSubExp=diffSubExposure, scoreSubExp=scoreSubExposure)
+    def finishResultExposures(self, diffExp, scoreExp=None):
+        """Perform final steps on the full difference exposure result.
+
+        Set photometric calibration, psf properties of the exposures.
+
+        Parameters
+        ----------
+        diffExp : `lsst.afw.image.Exposure`
+            The result difference image exposure to finalize.
+        scoreExp : `lsst.afw.image.Exposure` or `None`
+            The result score exposure to finalize.
+
+        Returns
+        -------
+        None.
+        """
+        # Set Calibration and PSF of the result exposures
+        calibOne = afwImage.PhotoCalib(1.)
+        diffExp.setPhotoCalib(calibOne)
+        # Create the spatially varying PSF and set it for the diffExp
+        # Set the PSF of this subExposure
+        if len(self.gridPsfs) > 1:
+            diffExp.setPsf(
+                self.makeSpatialPsf(
+                    pipeBase.Struct(bbox=x.bbox, psf=x.Pd) for x in self.gridPsfs
+                ))
+            if scoreExp is not None:
+                scoreExp.setPsf(
+                    self.makeSpatialPsf(
+                        pipeBase.Struct(bbox=x.bbox, psf=x.Ps) for x in self.gridPsfs
+                    ))
+        else:
+            # We did not have a grid, use the result psf without
+            # making a CoaddPsf
+            diffExp.setPsf(self.gridPsfs[0].Pd)
+            if scoreExp is not None:
+                scoreExp.setPsf(self.gridPsfs[0].Ps)
+
+        # diffExp.setPsf(self.makeKernelPsfFromArray(Pd))
+        if scoreExp is not None:
+            scoreExp.setPhotoCalib(calibOne)
+            # Zero score exposure where its variance is zero or the inputs are non-finite
+            flt = (self.filtsImg1.filtInf | self.filtsImg2.filtInf
+                   | self.filtsImg1.filtNaN | self.filtsImg2.filtNaN
+                   | self.filtsVar1.filtInf | self.filtsVar2.filtInf
+                   | self.filtsVar1.filtNaN | self.filtsVar2.filtNaN)
+            # Ensure that no division by 0 occurs in S/sigma(S).
+            # S is set to be always finite, 0 where pixels non-finite
+            tiny = np.finfo(scoreExp.variance.dtype).tiny * 100
+            flt = np.logical_or(flt, scoreExp.variance.array < tiny)
+            # Don't set variance to tiny.
+            # It becomes 0 in case of conversion to single precision.
+            # Set variance to 1, indicating that zero is in units of "sigmas" already.
+            scoreExp.variance.array[flt] = 1
+            scoreExp.image.array[flt] = 0
 
     def run(self, exposure1, exposure2, calculateScore=True):
         """Task entry point to perform the zogy subtraction
@@ -854,6 +1186,9 @@ class ZogyTask(pipeBase.Task):
         Notes
         -----
 
+        ``diffExp`` and ``scoreExp`` always inherit their metadata from
+        ``exposure1`` (e.g. dtype, bbox, wcs).
+
         The score image (``S``) is defined in the ZOGY paper as the detection
         statistic value at each pixel. In the ZOGY image model, the input images
         have uniform variance noises and thus ``S`` has uniform per pixel
@@ -871,13 +1206,14 @@ class ZogyTask(pipeBase.Task):
         variance plane. ``scoreExp`` can be used directly for source detection
         as a likelihood image by respecting its variance plane or can be divided
         by the square root of the variance plane to scale detection significance
-        values into units of sigma.
+        values into units of sigma. ``S`` should be interpreted as a detection
+        likelihood directly on a per-pixel basis. The calculated PSF
+        of ``S`` is merely an indication how much the input PSFs localize point
+        sources.
 
         TODO DM-23855 : Implement further correction tags to the variance of
         ``scoreExp``. As of DM-25174 it is not determined how important these
         further correction tags are.
-
-        TODO DM-23855 : spatially varying solution on a grid is not yet implemented
         """
         # We use the dimensions of the 1st image only in the code
         if exposure1.getDimensions() != exposure2.getDimensions():
@@ -885,23 +1221,41 @@ class ZogyTask(pipeBase.Task):
                              exposure1.getDimensions(), exposure2.getDimensions()))
 
         self.prepareFullExposure(exposure1, exposure2, correctBackground=self.config.correctBackground)
+        # Do not use the exposure1, exposure2 input arguments from here
+        exposure1 = None
+        exposure2 = None
+        if self.config.doSpatialGrid:
+            gridBoxes = self.generateGrid(
+                self.fullExp1.getBBox(ImageOrigin.LOCAL), Extent2I(self.borderSize, self.borderSize),
+                Extent2I(Extent2I(self.borderSize, self.borderSize) * self.config.gridInnerSize),
+                powerOfTwo=True)
+        else:
+            gridBoxes = self.generateGrid(
+                self.fullExp1.getBBox(ImageOrigin.LOCAL), Extent2I(self.borderSize, self.borderSize),
+                self.fullExp1.getBBox().getDimensions(), powerOfTwo=True)
 
-        # TODO DM-23855: Add grid splitting support here for spatially varying PSF support
-        # Passing exposure1,2 won't be ok here: they're not photometrically scaled.
-        # Use the modified full maskedImages here
-        self.prepareSubExposure()
-        ftDiff = self.calculateFourierDiffim(
-            self.psfFft1, self.fftFullIm1.imFft, self.fftVarPl1.imFft, self.F1, self.subExpVar1,
-            self.psfFft2, self.fftFullIm2.imFft, self.fftVarPl2.imFft, self.F2, self.subExpVar2,
-            calculateScore=calculateScore)
-        diffExp = self.makeDiffimSubExposure(ftDiff)
+        diffExp = self.fullExp1.clone()
+        if calculateScore:
+            scoreExp = self.fullExp1.clone()
+        else:
+            scoreExp = None
+        self.gridPsfs = []
+        # Loop through grid boxes
+        for boxPair in gridBoxes:
+            self.prepareSubExposure(boxPair)  # Extract sub images and fft
+            ftDiff = self.calculateFourierDiffim(
+                self.psfFft1, self.subImgFft1, self.subVarImgFft1, self.F1, self.subExpVar1,
+                self.psfFft2, self.subImgFft2, self.subVarImgFft2, self.F2, self.subExpVar2,
+                calculateScore=calculateScore)
+            self.pasteSubDiffImg(ftDiff, diffExp, scoreExp)  # Paste back result
+        self.finishResultExposures(diffExp, scoreExp)
         # Add debug info from the task instance
-        ftDiff.freqSpaceShape = self.freqSpaceShape
-        ftDiff.imgShape = self.imgShape
-        ftDiff.psfShape1 = self.psfShape1
-        ftDiff.psfShape2 = self.psfShape2
-        return pipeBase.Struct(diffExp=diffExp.diffSubExp,
-                               scoreExp=diffExp.scoreSubExp,
+        ftDiff.freqSpaceShape = self.freqSpaceShape  # The outer shape of the last grid cell
+        ftDiff.psfShape1 = self.psfShape1  # The psf image shape in exposure1
+        ftDiff.psfShape2 = self.psfShape2  # The psf image shape in exposure2
+        ftDiff.borderSize = self.borderSize  # The requested padding around the inner region
+        return pipeBase.Struct(diffExp=diffExp,
+                               scoreExp=scoreExp,
                                ftDiff=ftDiff)
 
 
@@ -910,7 +1264,7 @@ class ZogyImagePsfMatchConfig(ImagePsfMatchConfig):
 
     zogyConfig = pexConfig.ConfigField(
         dtype=ZogyConfig,
-        doc='ZogyTask config to use when running on complete exposure (non spatially-varying)',
+        doc='ZogyTask config to use',
     )
 
 
@@ -926,7 +1280,7 @@ class ZogyImagePsfMatchTask(ImagePsfMatchTask):
     def __init__(self, *args, **kwargs):
         ImagePsfMatchTask.__init__(self, *args, **kwargs)
 
-    def run(self, scienceExposure, templateExposure, doWarping=True, spatiallyVarying=False):
+    def run(self, scienceExposure, templateExposure, doWarping=True):
         """Register, PSF-match, and subtract two Exposures, ``scienceExposure - templateExposure``
         using the ZOGY algorithm.
 
@@ -940,8 +1294,6 @@ class ZogyImagePsfMatchTask(ImagePsfMatchTask):
             what to do if templateExposure's and scienceExposure's WCSs do not match:
             - if True then warp templateExposure to match scienceExposure
             - if False then raise an Exception
-        spatiallyVarying : `bool`
-            If True, perform the operation over a grid of patches across the two exposures
 
         Notes
         -----
@@ -951,7 +1303,6 @@ class ZogyImagePsfMatchTask(ImagePsfMatchTask):
 
         This is the new entry point of the task as of DM-25115.
 
-
         Returns
         -------
         results : `lsst.pipe.base.Struct` containing these fields:
@@ -960,10 +1311,6 @@ class ZogyImagePsfMatchTask(ImagePsfMatchTask):
             - warpedExposure: `lsst.afw.image.Exposure` or `None`
                 templateExposure after warping to match scienceExposure
         """
-
-        if spatiallyVarying:
-            raise NotImplementedError(
-                "DM-25115 Spatially varying zogy subtraction is not implemented.")
 
         if not self._validateWcs(scienceExposure, templateExposure):
             if doWarping:
@@ -983,14 +1330,10 @@ class ZogyImagePsfMatchTask(ImagePsfMatchTask):
         results.warpedExposure = templateExposure
         return results
 
-    def subtractExposures(self, templateExposure, scienceExposure,
-                          doWarping=True, spatiallyVarying=True, inImageSpace=False,
-                          doPreConvolve=False):
+    def subtractExposures(self, templateExposure, scienceExposure, *args):
         raise NotImplementedError
 
-    def subtractMaskedImages(self, templateExposure, scienceExposure,
-                             doWarping=True, spatiallyVarying=True, inImageSpace=False,
-                             doPreConvolve=False):
+    def subtractMaskedImages(self, templateExposure, scienceExposure, *args):
         raise NotImplementedError
 
 


### PR DESCRIPTION
 
 * Add grid generation method. Ensure outer box is always even.
 * Add border initialization by random noise method.
 * Add exposure split and paste back methods.
 * Add spatial psf construction by coaddPsf.
 * Set calib property to the score image as well.
 * Update some log messages to use f-methods to avoid unnecessary string formatting.
 * Remove unused code parts.
 * Add subexp variance robustness.