### PR TITLE
DM-30079: Corrupted documentation breaks documentation builds

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,11 +3,11 @@
 This configuration only affects single-package Sphinx documenation builds.
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.ip.diffim
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='ip_diffim',
-    version=lsst.ip.diffim.version.__version__))
+project = "ip_diffim"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project
+doxylink = {}

--- a/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask.rst
+++ b/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask.rst
@@ -30,10 +30,10 @@ Butler datasets
 Input datasets
 --------------
 
-:lsst-config-field:`~_lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricConfig.sciSources`
+``sciSources``
     The catalog type for science sources (default: ``src``).
 
-:lsst-config-field:`~_lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricConfig.diaSources`
+``diaSources``
     The catalog type for DIASources (default: ``deepDiff_diaSrc``).
 
 .. _lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask-subtasks:

--- a/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.NumberSciSourcesMetricTask.rst
+++ b/doc/lsst.ip.diffim/tasks/lsst.ip.diffim.metrics.NumberSciSourcesMetricTask.rst
@@ -29,7 +29,7 @@ Butler datasets
 Input datasets
 --------------
 
-:lsst-config-field:`~_lsst.ip.diffim.metrics.NumberSciSourcesMetricConfig.sources`
+``sources``
     The catalog type for science sources (default: ``src``).
 
 .. _lsst.ip.diffim.metrics.NumberSciSourcesMetricTask-subtasks:

--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -171,8 +171,7 @@ class DcrModel:
 
         Parameters
         ----------
-        availableCoaddRefs : `dict` of
-                `int` : `lsst.daf.butler.DeferredDatasetHandle`
+        availableCoaddRefs : `dict` [`int`, `lsst.daf.butler.DeferredDatasetHandle`]
             Dictionary of spatially relevant retrieved coadd patches,
             indexed by their sequential patch number.
         effectiveWavelength : `float`

--- a/python/lsst/ip/diffim/getTemplate.py
+++ b/python/lsst/ip/diffim/getTemplate.py
@@ -250,11 +250,11 @@ class GetCoaddAsTemplateTask(pipeBase.Task):
             Patches to consider for making the template exposure.
         skyCorners : list of `lsst.geom.SpherePoint`
             Sky corner coordinates to be covered by the template exposure.
-        availableCoaddRefs : `dict` of `int` : `lsst.daf.butler.DeferredDatasetHandle` (Gen3)
-        `dict` (Gen2)
+        availableCoaddRefs : `dict` [`int`]
             Dictionary of spatially relevant retrieved coadd patches,
-            indexed by their sequential patch number. In Gen3 mode, .get() is called,
-            in Gen2 mode, sensorRef.get(**coaddef) is called to retrieve the coadd.
+            indexed by their sequential patch number. In Gen3 mode, values are
+            `lsst.daf.butler.DeferredDatasetHandle` and ``.get()`` is called,
+            in Gen2 mode, ``sensorRef.get(**coaddef)`` is called to retrieve the coadd.
         sensorRef : `lsst.daf.persistence.ButlerDataRef`, Gen2 only
             Butler data reference to get coadd data.
             Must be `None` for Gen3.
@@ -378,8 +378,8 @@ class GetCoaddAsTemplateTask(pipeBase.Task):
     def bboxIntersectsCorners(self, bbox, wcs, otherCorners):
         """Returns true if the bbox with wcs intersects otherCorners
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         bbox : `lsst.geom.Box2I`
             specifying the bounding box of test region
         wcs : `lsst.afw.geom.SkyWcs`
@@ -387,8 +387,8 @@ class GetCoaddAsTemplateTask(pipeBase.Task):
         otherCorners : `list` of `lsst.geom.SpherePoint`
             ICRS coordinates specifying boundary of the other sky region
 
-        Returns:
-        --------
+        Returns
+        -------
         result: `bool`
            Does bbox/wcs intersect other corners?
         """

--- a/python/lsst/ip/diffim/imageDecorrelation.py
+++ b/python/lsst/ip/diffim/imageDecorrelation.py
@@ -452,7 +452,7 @@ class DecorrelateALKernelTask(pipeBase.Task):
             The corrected psf, same shape as `psfOld`, sum normed to 1.
 
         Notes
-        ----
+        -----
         There is no algorithmic guarantee that the corrected psf can
         meaningfully fit to the same size as the original one.
         """

--- a/python/lsst/ip/diffim/makeKernelBasisList.py
+++ b/python/lsst/ip/diffim/makeKernelBasisList.py
@@ -105,6 +105,17 @@ def generateAlardLuptonBasisList(config, targetFwhmPix=None, referenceFwhmPix=No
         are generated and appended to the list in the order of the polynomial parameter number.
         See `lsst.afw.math.polynomialFunction2D` documentation for more details.
 
+    Raises
+    ------
+    RuntimeError
+        - if ``config.kernelBasisSet`` is not equal to "alard-lupton"
+    ValueError
+        - if ``config.kernelSize`` is even
+        - if the number of Gaussians and the number of given
+          sigma values are not equal or
+        - if the number of Gaussians and the number of given
+          polynomial degree values are not equal
+
     Notes
     -----
     The polynomial functions (``f``) are always evaluated in the -1.0, +1.0 range in both x, y directions,
@@ -124,8 +135,8 @@ def generateAlardLuptonBasisList(config, targetFwhmPix=None, referenceFwhmPix=No
           convolution counterpart. [1]_ Only use 3 since the algorithm
           assumes 3 components.
 
-    Metadata fields
-    ---------------
+    **Metadata fields**
+
     ALBasisNGauss : `int`
         The number of base Gaussians in the AL basis functions.
     ALBasisDegGauss : `list` of `int`
@@ -140,21 +151,9 @@ def generateAlardLuptonBasisList(config, targetFwhmPix=None, referenceFwhmPix=No
 
     References
     ----------
-
     .. [1] Ulmer, W.: Inverse problem of linear combinations of Gaussian convolution kernels
        (deconvolution) and some applications to proton/photon dosimetry and image
        processing. http://iopscience.iop.org/0266-5611/26/8/085002  Equation 40
-
-    Raises
-    ------
-    RuntimeError
-        - if ``config.kernelBasisSet`` is not equal to "alard-lupton"
-    ValueError
-        - if ``config.kernelSize`` is even
-        - if the number of Gaussians and the number of given
-          sigma values are not equal or
-        - if the number of Gaussians and the number of given
-          polynomial degree values are not equal
     """
 
     if config.kernelBasisSet != "alard-lupton":

--- a/python/lsst/ip/diffim/psfMatch.py
+++ b/python/lsst/ip/diffim/psfMatch.py
@@ -537,8 +537,7 @@ class PsfMatchTask(pipeBase.Task):
     also performs background matching and returns the differential background model as an
     `lsst.afw.math.Kernel.SpatialFunction`.
 
-    Invoking the Task
-    -----------------
+    **Invoking the Task**
 
     As a base class, this Task is not directly invoked.  However, ``run()`` methods that are
     implemented on derived classes will make use of the core ``_solve()`` functionality,
@@ -588,8 +587,7 @@ class PsfMatchTask(pipeBase.Task):
          - Standard deviation of substamp diffim quality metrics across all KernelCandidates,
            for both the per-candidate (LOCAL) and SPATIAL residuals
 
-    Debug variables
-    ---------------
+    **Debug variables**
 
     The `lsst.pipe.base.cmdLineTask.CmdLineTask` command line task interface supports a
     flag -d/--debug to import @b debug.py from your PYTHONPATH.  The relevant contents of debug.py

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -863,18 +863,17 @@ class ZogyTask(pipeBase.Task):
 
         Parameters
         ----------
-        psf1, psf2, im1, im2, varPlane1, varPlane2 : `numpy.ndarray` of `numpy.complex`,
-        shape ``self.freqSpaceShape``
-            Psf, image and variance plane arrays respectively.
-            All arrays must be already in Fourier space.
-
-        varMean1, varMean2: `numpy.float` > 0.
+        psf1, psf2 : `numpy.ndarray`, (``self.freqSpaceShape``,)
+            Psf arrays. Must be already in Fourier space.
+        im1, im2 : `numpy.ndarray`, (``self.freqSpaceShape``,)
+            Image arrays. Must be already in Fourier space.
+        varPlane1, varPlane2 : `numpy.ndarray`, (``self.freqSpaceShape``,)
+            Variance plane arrays respectively. Must be already in Fourier space.
+        varMean1, varMean2 : `numpy.float` > 0.
             Average per-pixel noise variance in im1, im2 respectively. Used as weighing
             of input images. Must be greater than zero.
-
         F1, F2 : `numpy.float` > 0.
             Photometric scaling of the images. See eqs. (5)--(9)
-
         calculateScore : `bool`, optional
             If True (default), calculate and return the detection significance (score) image.
             Otherwise, these return fields are `None`.
@@ -883,20 +882,21 @@ class ZogyTask(pipeBase.Task):
         -------
         result : `pipe.base.Struct`
             All arrays are in Fourier space and have shape ``self.freqSpaceShape``.
-            - ``Fd`` : `float`
-                Photometric level of ``D``.
-            - ``D`` : `numpy.ndarray` of `numpy.complex`
-                The difference image.
-            - ``varplaneD`` : `numpy.ndarray` of `numpy.complex`
-                Variance plane of ``D``.
-            - ``Pd`` : `numpy.ndarray` of `numpy.complex`
-                PSF of ``D``.
-            - ``S`` : `numpy.ndarray` of `numpy.complex` or `None`
-                Significance (score) image.
-            - ``varplaneS`` : `numpy.ndarray` of `numpy.complex` or `None`
-                Variance plane of ``S``.
-            - ``Ps`` : `numpy.ndarray` of `numpy.complex`
-                PSF of ``S``.
+
+            ``Fd``
+                Photometric level of ``D`` (`float`).
+            ``D``
+                The difference image (`numpy.ndarray` [`numpy.complex`]).
+            ``varplaneD``
+                Variance plane of ``D`` (`numpy.ndarray` [`numpy.complex`]).
+            ``Pd``
+                PSF of ``D`` (`numpy.ndarray` [`numpy.complex`]).
+            ``S``
+                Significance (score) image (`numpy.ndarray` [`numpy.complex`] or `None`).
+            ``varplaneS``
+                Variance plane of ``S`` ((`numpy.ndarray` [`numpy.complex`] or `None`).
+            ``Ps``
+                PSF of ``S`` (`numpy.ndarray` [`numpy.complex`]).
 
         Notes
         -----
@@ -1193,7 +1193,7 @@ class ZogyTask(pipeBase.Task):
         variance (though it is not scaled to 1). In Section 3.3 of the paper,
         there are "corrections" defined to the score image to correct the
         significance values for some deviations from the image model. The first
-        of these corrections is the calculation of the _variance plane_ of ``S``
+        of these corrections is the calculation of the *variance plane* of ``S``
         allowing for different per pixel variance values by following the
         overall convolution operation on the pixels of the input images. ``S``
         scaled (divided) by its corrected per pixel noise is referred as

--- a/python/lsst/ip/diffim/zogy.py
+++ b/python/lsst/ip/diffim/zogy.py
@@ -228,10 +228,6 @@ class ZogyTask(pipeBase.Task):
             If True, generate white noise for non-overlapping region. Otherwise,
             zero padding will be used in the non-overlapping region.
 
-        Notes
-        -----
-        ``innerBox``, ``outerBox`` must be in the PARENT system of ``fullExp``.
-
         Returns
         -------
         result : `lsst.pipe.base.Struct`
@@ -240,6 +236,8 @@ class ZogyTask(pipeBase.Task):
 
         Notes
         -----
+        ``innerBox``, ``outerBox`` must be in the PARENT system of ``fullExp``.
+
         Supports the non-grid option when ``innerBox`` equals to the
         bounding box of ``fullExp``.
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,8 @@ ignore = E133, E226, E228, N802, N803, N806, E266, N812, N815, N816, W503
 # TODO: remove E266 when Task documentation is converted to rst in DM-14207.
 exclude =
     __init__.py,
+    doc/conf.py,
+    doc/_build/html/conf.py,
     diffimDetailLib.py,
     diffimLib.py
 


### PR DESCRIPTION
This PR fixes a duplicate `Notes` that was causing Sphinx to crash, as well as some less-urgent Sphinx warnings.