### PR TITLE
DM-31948: Revert variance plane decorrelation calculation to estimated approach.

### DIFF
--- a/python/lsst/ip/diffim/imageDecorrelation.py
+++ b/python/lsst/ip/diffim/imageDecorrelation.py
@@ -50,7 +50,7 @@ class DecorrelateALKernelConfig(pexConfig.Config):
     )
     completeVarPlanePropagation = pexConfig.Field(
         dtype=bool,
-        default=True,
+        default=False,
         doc="Compute the full effect of the decorrelated matching kernel on the variance plane."
             " Otherwise use a model weighed sum of the input variances."
     )


### PR DESCRIPTION
DM-30465 added a new config option, and the default value should have been set so that it maintained the previous operations.