### PR TITLE
DM-29955: Add ExposureInfo id getter

### DIFF
--- a/python/lsst/ip/diffim/modelPsfMatch.py
+++ b/python/lsst/ip/diffim/modelPsfMatch.py
@@ -353,6 +353,7 @@ class ModelPsfMatchTask(PsfMatchTask):
 
         self.log.info("Psf-match science exposure to reference")
         psfMatchedExposure = afwImage.ExposureF(exposure.getBBox(), exposure.getWcs())
+        psfMatchedExposure.info.id = exposure.info.id
         psfMatchedExposure.setFilterLabel(exposure.getFilterLabel())
         psfMatchedExposure.setPhotoCalib(exposure.getPhotoCalib())
         psfMatchedExposure.getInfo().setVisitInfo(exposure.getInfo().getVisitInfo())


### PR DESCRIPTION
This PR uses the `id` component added on lsst/afw#613.