### PR TITLE
DM-34830: Increase default template border size to 20

### DIFF
--- a/python/lsst/ip/diffim/getTemplate.py
+++ b/python/lsst/ip/diffim/getTemplate.py
@@ -44,7 +44,7 @@ __all__ = ["GetCoaddAsTemplateTask", "GetCoaddAsTemplateConfig",
 class GetCoaddAsTemplateConfig(pexConfig.Config):
     templateBorderSize = pexConfig.Field(
         dtype=int,
-        default=10,
+        default=20,
         doc="Number of pixels to grow the requested template image to account for warping"
     )
     coaddName = pexConfig.Field(
@@ -499,7 +499,7 @@ class GetTemplateConfig(pipeBase.PipelineTaskConfig,
                         pipelineConnections=GetTemplateConnections):
     templateBorderSize = pexConfig.Field(
         dtype=int,
-        default=10,
+        default=20,
         doc="Number of pixels to grow the requested template image to account for warping"
     )
     warp = pexConfig.ConfigField(


### PR DESCRIPTION
The border is ignored with current image differencing, but with the new image differencing task written on DM-33001 the default template border of 10 pixels results in NaNs present at the edge of the image difference. Increasing the border size to 20 ensures that there are no NaNs.