### PR TITLE
DM-27177: Deprecate transitional getFilterLabel API

### DIFF
--- a/python/lsst/ip/diffim/dcrModel.py
+++ b/python/lsst/ip/diffim/dcrModel.py
@@ -151,7 +151,7 @@ class DcrModel:
             subfilter = coaddRef.dataId["subfilter"]
             dcrCoadd = coaddRef.get()
             if filterLabel is None:
-                filterLabel = dcrCoadd.getFilterLabel()
+                filterLabel = dcrCoadd.getFilter()
             if psf is None:
                 psf = dcrCoadd.getPsf()
             if bbox is None:
@@ -463,7 +463,7 @@ class DcrModel:
         templateExposure = afwImage.ExposureF(bbox, self.wcs)
         templateExposure.setMaskedImage(maskedImage[bbox])
         templateExposure.setPsf(self.psf)
-        templateExposure.setFilterLabel(self.filter)
+        templateExposure.setFilter(self.filter)
         if self.photoCalib is None:
             raise RuntimeError("No PhotoCalib set for the DcrModel. "
                                "If the DcrModel was created from a masked image"

--- a/python/lsst/ip/diffim/getTemplate.py
+++ b/python/lsst/ip/diffim/getTemplate.py
@@ -340,7 +340,7 @@ class GetCoaddAsTemplateTask(pipeBase.Task):
             coaddExposure.maskedImage.assign(coaddPatch.maskedImage[overlapBox], overlapBox)
 
             if coaddFilterLabel is None:
-                coaddFilterLabel = coaddPatch.getFilterLabel()
+                coaddFilterLabel = coaddPatch.getFilter()
 
             # Retrieve the PSF for this coadd tract, if not already retrieved
             if coaddPsf is None and coaddPatch.hasPsf():
@@ -359,7 +359,7 @@ class GetCoaddAsTemplateTask(pipeBase.Task):
 
         coaddExposure.setPhotoCalib(coaddPhotoCalib)
         coaddExposure.setPsf(coaddPsf)
-        coaddExposure.setFilterLabel(coaddFilterLabel)
+        coaddExposure.setFilter(coaddFilterLabel)
         return coaddExposure
 
     def getCoaddDatasetName(self):
@@ -691,7 +691,7 @@ class GetTemplateTask(pipeBase.PipelineTask):
             raise RuntimeError("CoaddPsf could not be constructed")
 
         templateExposure.setPsf(coaddPsf)
-        templateExposure.setFilterLabel(coaddExposure.getFilterLabel())
+        templateExposure.setFilter(coaddExposure.getFilter())
         templateExposure.setPhotoCalib(coaddExposure.getPhotoCalib())
         return pipeBase.Struct(outputExposure=templateExposure)
 

--- a/python/lsst/ip/diffim/imagePsfMatch.py
+++ b/python/lsst/ip/diffim/imagePsfMatch.py
@@ -451,7 +451,7 @@ class ImagePsfMatchTask(PsfMatchTask):
                 templateFwhmPix=scienceFwhmPix, scienceFwhmPix=templateFwhmPix)
 
         psfMatchedExposure = afwImage.makeExposure(results.matchedImage, scienceExposure.getWcs())
-        psfMatchedExposure.setFilterLabel(templateExposure.getFilterLabel())
+        psfMatchedExposure.setFilter(templateExposure.getFilter())
         psfMatchedExposure.setPhotoCalib(scienceExposure.getPhotoCalib())
         results.warpedExposure = templateExposure
         results.matchedExposure = psfMatchedExposure

--- a/python/lsst/ip/diffim/modelPsfMatch.py
+++ b/python/lsst/ip/diffim/modelPsfMatch.py
@@ -358,7 +358,7 @@ class ModelPsfMatchTask(PsfMatchTask):
         self.log.info("Psf-match science exposure to reference")
         psfMatchedExposure = afwImage.ExposureF(exposure.getBBox(), exposure.getWcs())
         psfMatchedExposure.info.id = exposure.info.id
-        psfMatchedExposure.setFilterLabel(exposure.getFilterLabel())
+        psfMatchedExposure.setFilter(exposure.getFilter())
         psfMatchedExposure.setPhotoCalib(exposure.getPhotoCalib())
         psfMatchedExposure.getInfo().setVisitInfo(exposure.getInfo().getVisitInfo())
         psfMatchedExposure.setPsf(referencePsfModel)

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -487,7 +487,7 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
             # check PSF, WCS, bbox, filterLabel, photoCalib, aperture correction
             self._compare_apCorrMaps(apCorrMap, output.difference.info.getApCorrMap())
             self.assertWcsAlmostEqualOverBBox(science.getWcs(), output.difference.getWcs(), science.getBBox())
-            self.assertEqual(science.getFilterLabel(), output.difference.getFilterLabel())
+            self.assertEqual(science.getFilter(), output.difference.getFilter())
             self.assertEqual(science.getPhotoCalib(), output.difference.getPhotoCalib())
         _run_and_check_images(doDecorrelation=True)
         _run_and_check_images(doDecorrelation=False)
@@ -536,7 +536,7 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
             # check PSF, WCS, bbox, filterLabel, photoCalib, aperture correction
             self._compare_apCorrMaps(apCorrMap, output.difference.info.getApCorrMap())
             self.assertWcsAlmostEqualOverBBox(science.getWcs(), output.difference.getWcs(), science.getBBox())
-            self.assertEqual(science.getFilterLabel(), output.difference.getFilterLabel())
+            self.assertEqual(science.getFilter(), output.difference.getFilter())
             self.assertEqual(science.getPhotoCalib(), output.difference.getPhotoCalib())
 
         _run_and_check_images(doDecorrelation=True)


### PR DESCRIPTION
This PR removes references to `getFilterLabel` and similarly-named methods, replacing them with `getFilter` (etc.) methods backed by `FilterLabel`.