### PR TITLE
DM-35817: Turn off compatibility mode as the default.

### DIFF
--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -99,7 +99,7 @@ class AlardLuptonSubtractConfig(lsst.pipe.base.PipelineTaskConfig,
                                 pipelineConnections=AlardLuptonSubtractConnections):
     mode = lsst.pex.config.ChoiceField(
         dtype=str,
-        default="auto",
+        default="convolveTemplate",
         allowed={"auto": "Choose which image to convolve at runtime.",
                  "convolveScience": "Only convolve the science image.",
                  "convolveTemplate": "Only convolve the template image."},
@@ -148,7 +148,7 @@ class AlardLuptonSubtractConfig(lsst.pipe.base.PipelineTaskConfig,
 
     forceCompatibility = lsst.pex.config.Field(
         dtype=bool,
-        default=True,
+        default=False,
         doc="Set up and run diffim using settings that ensure the results"
         "are compatible with the old version in pipe_tasks.",
         deprecated="This option is only for backwards compatibility purposes"
@@ -162,8 +162,10 @@ class AlardLuptonSubtractConfig(lsst.pipe.base.PipelineTaskConfig,
         self.makeKernel.kernel.active.spatialBgOrder = 2
 
     def validate(self):
-        if self.forceCompatibility:
-            self.mode = "convolveTemplate"
+        if self.forceCompatibility and not (self.mode == "convolveTemplate"):
+            msg = f"forceCompatibility=True requires mode='convolveTemplate', but mode was '{self.mode}'."
+            raise lsst.pex.config.FieldValidationError(AlardLuptonSubtractConfig.forceCompatibility,
+                                                       self, msg)
 
 
 class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -155,8 +155,18 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config.mode = "auto"
         config.forceCompatibility = True
+        # Ensure we're not trying to change config values inside validate().
+        config.freeze()
+        with self.assertRaises(FieldValidationError):
+            config.validate()
+
+        config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
+        config.mode = "convolveTemplate"
+        config.forceCompatibility = True
+        # Ensure we're not trying to change config values inside validate().
+        config.freeze()
+        # Should not raise:
         config.validate()
-        self.assertEqual(config.mode, "convolveTemplate")
 
     def test_mismatched_template(self):
         """Test that an error is raised if the template
@@ -207,7 +217,6 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config.doSubtractBackground = False
         config.mode = "convolveTemplate"
-        config.forceCompatibility = False
 
         task = subtractImages.AlardLuptonSubtractTask(config=config)
         output = task.run(template.clone(), science.clone(), sources)
@@ -228,7 +237,6 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config.doSubtractBackground = False
         config.mode = "convolveScience"
-        config.forceCompatibility = False
 
         task = subtractImages.AlardLuptonSubtractTask(config=config)
         output = task.run(template.clone(), science.clone(), sources)
@@ -252,6 +260,7 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
             config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
             config.doSubtractBackground = False
             config.forceCompatibility = False
+            config.mode = "convolveScience"
             task = subtractImages.AlardLuptonSubtractTask(config=config)
             output = task.run(template, science, sources)
             self.assertFloatsAlmostEqual(task.metadata["scaleTemplateVarianceFactor"], 1., atol=.05)
@@ -330,7 +339,6 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config.mode = 'auto'
         config.doSubtractBackground = False
-        config.forceCompatibility = False
         task = subtractImages.AlardLuptonSubtractTask(config=config)
 
         # The science image will be modified in place, so use a copy for the second run.
@@ -426,7 +434,6 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
                                          xSize=xSize, ySize=ySize, x0=x0, y0=y0)
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config.doSubtractBackground = True
-        config.forceCompatibility = False
 
         config.makeKernel.kernel.name = "AL"
         config.makeKernel.kernel.active.fitForBackground = True
@@ -542,6 +549,7 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
             """
 
             config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
+            config.mode = "convolveScience"
             config.doSubtractBackground = False
             config.forceCompatibility = False
             config.doDecorrelation = doDecorrelation
@@ -619,7 +627,6 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
 
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config.mode = "convolveTemplate"
-        config.forceCompatibility = False
 
         def _run_and_check_images(doDecorrelation):
             """Check that the metadata is correct with or without decorrelation.
@@ -669,7 +676,6 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
 
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config.mode = "convolveScience"
-        config.forceCompatibility = False
 
         def _run_and_check_images(doDecorrelation):
             """Check that the metadata is correct with or without decorrelation.


### PR DESCRIPTION
Also set the default convolution mode to `convolveTemplate`