### PR TITLE
DM-33256: Remove Gen 2 support from verify

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 Copyright 2015-2019 The Trustees of Princeton University
-Copyright 2014-2019 University of Washington
+Copyright 2014-2022 University of Washington
 Copyright 2015-2016, 2018 Association of Universities for Research in Astronomy
 Copyright 2014-2015, 2017 The Regents of the University of California
 Copyright 2016 University of Illinois Board of Trustees

--- a/python/lsst/ip/diffim/metrics.py
+++ b/python/lsst/ip/diffim/metrics.py
@@ -31,7 +31,6 @@ import astropy.units as u
 
 from lsst.pipe.base import Struct, connectionTypes
 from lsst.verify import Measurement
-from lsst.verify.gen2tasks import register
 from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections, \
     MetricComputationError
 
@@ -56,7 +55,6 @@ class NumberSciSourcesMetricConfig(
     pass
 
 
-@register("numSciSources")
 class NumberSciSourcesMetricTask(MetricTask):
     """Task that computes the number of cataloged non-primary science sources.
 
@@ -122,7 +120,6 @@ class FractionDiaSourcesToSciSourcesMetricConfig(
     pass
 
 
-@register("fracDiaSourcesToSciSources")
 class FractionDiaSourcesToSciSourcesMetricTask(MetricTask):
     """Task that computes the ratio of difference image sources to science
     sources in an image, visit, etc.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -28,7 +28,7 @@ from lsst.afw.table import SourceCatalog
 import lsst.utils.tests
 import lsst.pipe.base.testUtils
 from lsst.verify import Name
-from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
+from lsst.verify.tasks.testUtils import MetricTaskTestCase
 from lsst.verify.tasks import MetricComputationError
 
 from lsst.ip.diffim.metrics import \


### PR DESCRIPTION
This PR removes use of the `lsst.verify.gen2tasks.register` decorator, which is removed in lsst/verify#103.