### PR TITLE
DM-35721: Fix docs for image differencing tasks

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -267,9 +267,9 @@ class DetectAndMeasureTask(lsst.pipe.base.PipelineTask):
             difference image.
         difference : `lsst.afw.image.ExposureF`
             Result of subtracting template from the science image.
-        selectSources : `lsst.afw.table.SourceCatalog`, optional
+        selectSources : `lsst.afw.table.SourceCatalog`
             Identified sources on the science exposure.
-        idFactory : `lsst.afw.table.IdFactory`
+        idFactory : `lsst.afw.table.IdFactory`, optional
             Generator object to assign ids to detected sources in the difference image.
 
         Returns

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -254,7 +254,7 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
                 Result of subtracting template and science.
             ``matchedTemplate`` : `lsst.afw.image.ExposureF`
                 Warped and PSF-matched template exposure.
-            ``backgroundModel`` : `lsst.afw.math.Chebyshev1Function2D`
+            ``backgroundModel`` : `lsst.afw.math.Function2D`
                 Background model that was fit while solving for the PSF-matching kernel
             ``psfMatchingKernel`` : `lsst.afw.math.Kernel`
                 Kernel used to PSF-match the convolved image.
@@ -348,7 +348,7 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
                 Result of subtracting template and science.
             ``matchedTemplate`` : `lsst.afw.image.ExposureF`
                 Warped and PSF-matched template exposure.
-            ``backgroundModel`` : `lsst.afw.math.Chebyshev1Function2D`
+            ``backgroundModel`` : `lsst.afw.math.Function2D`
                 Background model that was fit while solving for the PSF-matching kernel
             ``psfMatchingKernel`` : `lsst.afw.math.Kernel`
                 Kernel used to PSF-match the template to the science image.
@@ -399,7 +399,7 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
             ``matchedTemplate`` : `lsst.afw.image.ExposureF`
                 Warped template exposure. Note that in this case, the template
                 is not PSF-matched to the science image.
-            ``backgroundModel`` : `lsst.afw.math.Chebyshev1Function2D`
+            ``backgroundModel`` : `lsst.afw.math.Function2D`
                 Background model that was fit while solving for the PSF-matching kernel
             ``psfMatchingKernel`` : `lsst.afw.math.Kernel`
                Kernel used to PSF-match the science image to the template.


### PR DESCRIPTION
This PR makes a few documentation fixes discovered while creating mock tasks for lsst/ap_verify#167.