### PR TITLE
DM-38209: Fix module string in compiled module

### DIFF
--- a/python/lsst/ip/diffim/_ipdiffimLib.cc
+++ b/python/lsst/ip/diffim/_ipdiffimLib.cc
@@ -47,7 +47,7 @@ namespace detail {
     void wrapKernelSumVisitor(WrapperCollection &wrappers);
 }
 PYBIND11_MODULE(_ipdiffimLib, mod) {
-    lsst::utils::python::WrapperCollection wrappers(mod, "ip.diffim");
+    lsst::utils::python::WrapperCollection wrappers(mod, "lsst.ip.diffim");
     wrappers.addInheritanceDependency("lsst.meas.base");
     wrappers.addInheritanceDependency("lsst.afw.math");
     wrappers.addSignatureDependency("lsst.afw.table");


### PR DESCRIPTION
Correct the compiled module to report the correct qualified import path.