### PR TITLE
DM-38901: Clear the template mask plane in image differencing

### DIFF
--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -512,8 +512,17 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
         mask = difference.mask
         mask &= ~(mask.getPlaneBitMask("DETECTED") | mask.getPlaneBitMask("DETECTED_NEGATIVE"))
 
+        # We have cleared the template mask plane, so copy the mask plane of
+        # the image difference so that we can calculate correct statistics
+        # during decorrelation. Do this regardless of whether decorrelation is
+        # used for consistency.
+        template[science.getBBox()].mask.array[...] = difference.mask.array[...]
         if self.config.doDecorrelation:
             self.log.info("Decorrelating image difference.")
+            # We have cleared the template mask plane, so copy the mask plane of
+            # the image difference so that we can calculate correct statistics
+            # during decorrelation
+            template[science.getBBox()].mask.array[...] = difference.mask.array[...]
             correctedExposure = self.decorrelate.run(science, template[science.getBBox()], difference, kernel,
                                                      templateMatched=templateMatched,
                                                      preConvMode=preConvMode,

--- a/python/lsst/ip/diffim/utils.py
+++ b/python/lsst/ip/diffim/utils.py
@@ -1239,6 +1239,7 @@ def makeTestImage(seed=5, nSrc=20, psfSize=2., noiseLevel=5.,
                   xLoc=None,
                   yLoc=None,
                   flux=None,
+                  clearEdgeMask=False,
                   ):
     """Make a reproduceable PSF-convolved exposure for testing.
 
@@ -1278,6 +1279,8 @@ def makeTestImage(seed=5, nSrc=20, psfSize=2., noiseLevel=5.,
     flux : `list` of `float`, optional
         User-specified fluxes of the simulated sources.
         If specified, must have length equal to ``nSrc``
+    clearEdgeMask : `bool`, optional
+        Clear the "EDGE" mask plane after source detection.
 
     Returns
     -------
@@ -1285,6 +1288,11 @@ def makeTestImage(seed=5, nSrc=20, psfSize=2., noiseLevel=5.,
         The model image, with the mask and variance planes.
     sourceCat : `lsst.afw.table.SourceCatalog`
         Catalog of sources detected on the model image.
+
+    Raises
+    ------
+    ValueError
+        If `xloc`, `yloc`, or `flux` are supplied with inconsistant lengths.
     """
     # Distance from the inner edge of the bounding box to avoid placing test
     # sources in the model images.
@@ -1327,6 +1335,8 @@ def makeTestImage(seed=5, nSrc=20, psfSize=2., noiseLevel=5.,
 
     # Run source detection to set up the mask plane
     sourceCat = detectTestSources(modelExposure)
+    if clearEdgeMask:
+        modelExposure.mask &= ~modelExposure.mask.getPlaneBitMask("EDGE")
     modelExposure.setPhotoCalib(afwImage.PhotoCalib(calibration, 0., bbox))
     if background is not None:
         modelExposure.image += background

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -281,7 +281,7 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
         # Don't include a border for the template, in order to make the results
         #  comparable when we swap which image is treated as the "science" image.
         science, sources = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel,
-                                         noiseSeed=6, templateBorderSize=0)
+                                         noiseSeed=6, templateBorderSize=0, doApplyCalibration=True)
         template, _ = makeTestImage(psfSize=3.0, noiseLevel=noiseLevel,
                                     noiseSeed=7, templateBorderSize=0, doApplyCalibration=True)
         config = subtractImages.AlardLuptonSubtractTask.ConfigClass()
@@ -329,18 +329,22 @@ class AlardLuptonSubtractTest(lsst.utils.tests.TestCase):
         noiseLevel = .1
         seed1 = 6
         seed2 = 7
-        science1, sources1 = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=seed1)
+        science1, sources1 = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=seed1,
+                                           clearEdgeMask=True)
         template1, _ = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=seed2,
-                                     templateBorderSize=0, doApplyCalibration=True)
+                                     templateBorderSize=0, doApplyCalibration=True,
+                                     clearEdgeMask=True)
         config1 = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config1.mode = "convolveTemplate"
         config1.doSubtractBackground = False
         task1 = subtractImages.AlardLuptonSubtractTask(config=config1)
         results_convolveTemplate = task1.run(template1, science1, sources1)
 
-        science2, sources2 = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=seed1)
+        science2, sources2 = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=seed1,
+                                           clearEdgeMask=True)
         template2, _ = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=seed2,
-                                     templateBorderSize=0, doApplyCalibration=True)
+                                     templateBorderSize=0, doApplyCalibration=True,
+                                     clearEdgeMask=True)
         config2 = subtractImages.AlardLuptonSubtractTask.ConfigClass()
         config2.mode = "convolveScience"
         config2.doSubtractBackground = False


### PR DESCRIPTION
A few minor bugs uncovered while working on this ticket are also fixed.