### PR TITLE
DM-39306: Update SourceDetectionTasks to use excludeMaskPlanes EDGE by default.

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -148,6 +148,7 @@ class DetectAndMeasureConfig(pipeBase.PipelineTaskConfig,
         self.detection.thresholdValue = 5.0
         self.detection.reEstimateBackground = False
         self.detection.thresholdType = "pixel_stdev"
+        self.detection.excludeMaskPlanes = ["EDGE"]
 
         # Add filtered flux measurement, the correct measurement for pre-convolved images.
         self.measurement.algorithms.names.add('base_PeakLikelihoodFlux')

--- a/python/lsst/ip/diffim/makeKernel.py
+++ b/python/lsst/ip/diffim/makeKernel.py
@@ -75,6 +75,7 @@ class MakeKernelConfig(PsfMatchConfig):
         # High sigma detections only
         self.selectDetection.reEstimateBackground = False
         self.selectDetection.thresholdValue = 10.0
+        self.selectDetection.excludeMaskPlanes = ["EDGE"]
 
         # Minimal set of measurments for star selection
         self.selectMeasurement.algorithms.names.clear()

--- a/python/lsst/ip/diffim/utils.py
+++ b/python/lsst/ip/diffim/utils.py
@@ -1048,6 +1048,7 @@ class DipoleTestImage(object):
         # detectConfig.nSigmaToGrow = psfSigma
         detectConfig.reEstimateBackground = True  # if False, will fail often for faint sources on gradients?
         detectConfig.thresholdType = "pixel_stdev"
+        detectConfig.excludeMaskPlanes = ["EDGE"]
         # Test images are often quite small, so may need to adjust background binSize
         while ((min(diffim.getWidth(), diffim.getHeight()))//detectConfig.background.binSize
                < detectConfig.background.approxOrderX and detectConfig.background.binSize > minBinSize):


### PR DESCRIPTION
This PR moves the excludeMaskPlanes default from the SourceDetectionTask default to the tasks within ip_diffim which need this override.