### PR TITLE
DM-41876: Reject sources flagged with *CenterAll

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -143,6 +143,9 @@ class DetectAndMeasureConfig(pipeBase.PipelineTaskConfig,
         dtype=str,
         doc="Sources with any of these flags set are removed before writing the output catalog.",
         default=("base_PixelFlags_flag_offimage",
+                 "base_PixelFlags_flag_interpolatedCenterAll",
+                 "base_PixelFlags_flag_badCenterAll",
+                 "base_PixelFlags_flag_edgeCenterAll",
                  ),
     )
     idGenerator = DetectorVisitIdGeneratorConfig.make_field()

--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -397,6 +397,7 @@ class DetectAndMeasureTask(lsst.pipe.base.PipelineTask):
             Seed value to initialize the random number generator.
         """
         skySourceFootprints = self.skySources.run(mask=mask, seed=seed)
+        self.metadata.add("nSkySources", len(skySourceFootprints))
         if skySourceFootprints:
             for foot in skySourceFootprints:
                 s = diaSources.addNew()

--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -181,6 +181,7 @@ class DetectAndMeasureConfig(pipeBase.PipelineTaskConfig,
             "STREAK", "INJECTED", "INJECTED_TEMPLATE"]
         self.measurement.plugins["base_PixelFlags"].masksFpCenter = [
             "STREAK", "INJECTED", "INJECTED_TEMPLATE"]
+        self.skySources.avoidMask = ["DETECTED", "DETECTED_NEGATIVE", "BAD", "NO_DATA", "EDGE"]
 
 
 class DetectAndMeasureTask(lsst.pipe.base.PipelineTask):

--- a/tests/test_detectAndMeasure.py
+++ b/tests/test_detectAndMeasure.py
@@ -728,8 +728,9 @@ class DetectAndMeasureScoreTest(DetectAndMeasureTestBase):
 
         # Run detection and check the results
         output = detectionTask.run(science, matchedTemplate, difference, score)
+        nSkySourcesGenerated = detectionTask.metadata["nSkySources"]
         skySources = output.diaSources[output.diaSources["sky_source"]]
-        self.assertEqual(len(skySources), detectionTask.config.skySources.nSources)
+        self.assertEqual(len(skySources), nSkySourcesGenerated)
         for skySource in skySources:
             # The sky sources should not be close to any other source
             with self.assertRaises(AssertionError):


### PR DESCRIPTION
Includes `interpolated`, `bad`, and `edge` source flags.