### PR TITLE
DM-42999: Demote routine "warnings" and fix build problems

### DIFF
--- a/python/lsst/ip/diffim/dipoleFitTask.py
+++ b/python/lsst/ip/diffim/dipoleFitTask.py
@@ -1239,7 +1239,7 @@ class DipoleFitPlugin(measBase.SingleFramePlugin):
         measRecord.set(self.flagKey, True)
         if error is not None:
             if error.getFlagBit() == self.FAILURE_EDGE:
-                self.log.warning('DipoleFitPlugin not run on record %d: %s', measRecord.getId(), str(error))
+                self.log.debug('DipoleFitPlugin not run on record %d: %s', measRecord.getId(), str(error))
                 measRecord.set(self.edgeFlagKey, True)
             if error.getFlagBit() == self.FAILURE_FIT:
                 self.log.warning('DipoleFitPlugin failed on record %d: %s', measRecord.getId(), str(error))

--- a/python/lsst/ip/diffim/getTemplate.py
+++ b/python/lsst/ip/diffim/getTemplate.py
@@ -127,8 +127,8 @@ class GetTemplateTask(pipeBase.PipelineTask):
         Parameters
         ----------
         inputs : `dict` of task Inputs, containing:
-            - coaddExposureRefs : `list`
-                                [`lsst.daf.butler.DeferredDatasetHandle` of
+            - coaddExposureRefs : `list` \
+                                [`lsst.daf.butler.DeferredDatasetHandle` of \
                                 `lsst.afw.image.Exposure`]
                 Data references to exposures that might overlap the detector.
             - bbox : `lsst.geom.Box2I`
@@ -373,8 +373,8 @@ class GetDcrTemplateTask(GetTemplateTask):
         Parameters
         ----------
         inputs : `dict` of task Inputs, containing:
-            - coaddExposureRefs : `list`
-                                  [`lsst.daf.butler.DeferredDatasetHandle` of
+            - coaddExposureRefs : `list` \
+                                  [`lsst.daf.butler.DeferredDatasetHandle` of \
                                   `lsst.afw.image.Exposure`]
                 Data references to exposures that might overlap the detector.
             - bbox : `lsst.geom.Box2I`

--- a/python/lsst/ip/diffim/imageDecorrelation.py
+++ b/python/lsst/ip/diffim/imageDecorrelation.py
@@ -507,7 +507,7 @@ class DecorrelateALKernelTask(pipeBase.Task):
           as a weighted sum of the input variances.
 
         Notes
-        ------
+        -----
         See DMTN-179 Section 5 about the variance plane calculations.
         """
         w1 = np.sum(np.real(np.conj(c1ft)*c1ft)) / c1ft.size
@@ -541,7 +541,7 @@ class DecorrelateALKernelTask(pipeBase.Task):
           The variance plane of the difference/score images.
 
         Notes
-        ------
+        -----
         See DMTN-179 Section 5 about the variance plane calculations.
 
         Infs and NaNs are allowed and kept in the returned array.

--- a/src/BasisLists.cc
+++ b/src/BasisLists.cc
@@ -11,8 +11,6 @@
 #include <cmath>
 #include <limits>
 
-#include "boost/timer.hpp"
-
 #include "lsst/pex/exceptions/Exception.h"
 #include "lsst/daf/base/PropertySet.h"
 #include "lsst/afw/image.h"

--- a/src/BuildSpatialKernelVisitor.cc
+++ b/src/BuildSpatialKernelVisitor.cc
@@ -10,7 +10,6 @@
  */
 
 #include <memory>
-#include "boost/timer.hpp"
 
 #include "Eigen/Core"
 #include "Eigen/Cholesky"

--- a/src/ImageSubtract.cc
+++ b/src/ImageSubtract.cc
@@ -35,7 +35,7 @@
 #include <numeric>
 #include <limits>
 
-#include "boost/timer.hpp"
+#include "boost/timer/timer.hpp"
 
 #include "Eigen/Core"
 
@@ -120,8 +120,7 @@ afwImage::MaskedImage<PixelT> convolveAndSubtract(
     bool invert                                              ///< Invert the output difference image
     ) {
 
-    boost::timer t;
-    t.restart();
+    boost::timer::cpu_timer t;
 
     afwImage::MaskedImage<PixelT> convolvedMaskedImage(templateImage.getDimensions());
     afwMath::ConvolutionControl convolutionControl = afwMath::ConvolutionControl();
@@ -140,7 +139,8 @@ afwImage::MaskedImage<PixelT> convolveAndSubtract(
         convolvedMaskedImage *= -1.0;
     }
 
-    double time = t.elapsed();
+    t.stop();
+    double time = 1e-9 * t.elapsed().wall;
     LOGL_DEBUG("TRACE4.ip.diffim.convolveAndSubtract",
                "Total compute time to convolve and subtract : %.2f s", time);
 
@@ -171,8 +171,7 @@ afwImage::MaskedImage<PixelT> convolveAndSubtract(
     bool invert                                              ///< Invert the output difference image
     ) {
 
-    boost::timer t;
-    t.restart();
+    boost::timer::cpu_timer t;
 
     afwImage::MaskedImage<PixelT> convolvedMaskedImage(templateImage.getDimensions());
     afwMath::ConvolutionControl convolutionControl = afwMath::ConvolutionControl();
@@ -193,7 +192,8 @@ afwImage::MaskedImage<PixelT> convolveAndSubtract(
     convolvedMaskedImage.getMask()->assign(*scienceMaskedImage.getMask());
     convolvedMaskedImage.getVariance()->assign(*scienceMaskedImage.getVariance());
 
-    double time = t.elapsed();
+    t.stop();
+    double time = 1e-9 * t.elapsed().wall;
     LOGL_DEBUG("TRACE4.ip.diffim.convolveAndSubtract",
                "Total compute time to convolve and subtract : %.2f s", time);
 

--- a/src/KernelCandidate.cc
+++ b/src/KernelCandidate.cc
@@ -9,7 +9,6 @@
  * @ingroup ip_diffim
  */
 #include <stdexcept>
-#include "boost/timer.hpp"
 
 #include "lsst/afw/math.h"
 #include "lsst/afw/image.h"

--- a/src/KernelSolution.cc
+++ b/src/KernelSolution.cc
@@ -14,7 +14,7 @@
 #include <limits>
 
 #include <memory>
-#include "boost/timer.hpp"
+#include "boost/timer/timer.hpp"
 
 #include "Eigen/Core"
 #include "Eigen/Cholesky"
@@ -140,8 +140,7 @@ namespace diffim {
 
         Eigen::VectorXd aVec = Eigen::VectorXd::Zero(bVec.size());
 
-        boost::timer t;
-        t.restart();
+        boost::timer::cpu_timer t;
 
         LOGL_DEBUG("TRACE2.ip.diffim.KernelSolution.solve",
                    "Solving for kernel");
@@ -177,7 +176,8 @@ namespace diffim {
 			}
 		}
 
-        double time = t.elapsed();
+        t.stop();
+        double time = 1e-9 * t.elapsed().wall;
         LOGL_DEBUG("TRACE3.ip.diffim.KernelSolution.solve",
                    "Compute time for matrix math : %.2f s", time);
 
@@ -322,8 +322,7 @@ namespace diffim {
         unsigned int endCol = goodBBox.getMaxX() + 1;
         unsigned int endRow = goodBBox.getMaxY() + 1;
 
-        boost::timer t;
-        t.restart();
+        boost::timer::cpu_timer t;
 
         /* Eigen representation of input images; only the pixels that are unconvolved in cimage below */
         Eigen::MatrixXd eigenTemplate = imageToEigenMatrix(templateImage).block(startRow,
@@ -366,10 +365,10 @@ namespace diffim {
 
         }
 
-        double time = t.elapsed();
+        t.stop();
+        double time = 1e-9 * t.elapsed().wall;
         LOGL_DEBUG("TRACE3.ip.diffim.StaticKernelSolution.build",
                    "Total compute time to do basis convolutions : %.2f s", time);
-        t.restart();
 
         /*
            Load matrix with all values from convolvedEigenList : all images
@@ -600,8 +599,7 @@ namespace diffim {
         }
 
 
-        boost::timer t;
-        t.restart();
+        boost::timer::cpu_timer t;
 
         unsigned int const nKernelParameters     = basisList.size();
         unsigned int const nBackgroundParameters = this->_fitForBackground ? 1 : 0;
@@ -638,10 +636,10 @@ namespace diffim {
 
             *eiter = eigenC;
         }
-        double time = t.elapsed();
+        t.stop();
+        double time = 1e-9 * t.elapsed().wall;
         LOGL_DEBUG("TRACE3.ip.diffim.StaticKernelSolution.buildWithMask",
                    "Total compute time to do basis convolutions : %.2f s", time);
-        t.restart();
 
         /* Load matrix with all convolved images */
         Eigen::MatrixXd cMat(eigenTemplate.size(), nParameters);
@@ -720,8 +718,7 @@ namespace diffim {
         endCol += 1;
         endRow += 1;
 
-        boost::timer t;
-        t.restart();
+        boost::timer::cpu_timer t;
 
         /* Eigen representation of input images; only the pixels that are unconvolved in cimage below */
         Eigen::MatrixXi eMask = maskToEigenMatrix(sMask).block(startRow,
@@ -799,10 +796,10 @@ namespace diffim {
             *eiter = cMat;
         }
 
-        double time = t.elapsed();
+        t.stop();
+        double time = 1e-9 * t.elapsed().wall;
         LOGL_DEBUG("TRACE3.ip.diffim.StaticKernelSolution.build",
                    "Total compute time to do basis convolutions : %.2f s", time);
-        t.restart();
 
         /*
            Load matrix with all values from convolvedEigenList : all images
@@ -973,8 +970,7 @@ namespace diffim {
         eigenScience.setZero();
         eigeniVariance.setZero();
 
-        boost::timer t;
-        t.restart();
+        boost::timer::cpu_timer t;
 
         int nTerms = 0;
         typename std::vector<geom::Box2I>::iterator biter = boxArray.begin();
@@ -1029,10 +1025,10 @@ namespace diffim {
 
         }
 
-        double time = t.elapsed();
+        t.stop();
+        double time = 1e-9 * t.elapsed().wall;
         LOGL_DEBUG("TRACE3.ip.diffim.MaskedKernelSolution.build",
                    "Total compute time to do basis convolutions : %.2f s", time);
-        t.restart();
 
         /*
            Load matrix with all values from convolvedEigenList : all images

--- a/ups/ip_diffim.cfg
+++ b/ups/ip_diffim.cfg
@@ -4,7 +4,7 @@ import lsst.sconsUtils
 
 dependencies = {
     "required": ["meas_base", "afw", "numpy", "minuit2", "log", "daf_base"],
-    "buildRequired": ["pybind11"],
+    "buildRequired": ["boost_timer", "pybind11"],
 }
 
 config = lsst.sconsUtils.Configuration(


### PR DESCRIPTION
This PR demotes a `warning` log emitted whenever an image has sources in the edge region to a `debug`. In addition, it fixes a number of Sphinx/Numpydoc warnings and a deprecation warning with Boost Timer. Because of the last, this PR must be merged after lsst/sconsUtils#120.

There are still build warnings for the Doxygen docs, but the root cause (components have documentation comments in both the header and source files, and they _do not_ agree) goes far beyond the scale of continuous cleanup.