### PR TITLE
DM-44494: Change DipoleFit "orientation" from degrees to radians.

### DIFF
--- a/python/lsst/ip/diffim/dipoleFitTask.py
+++ b/python/lsst/ip/diffim/dipoleFitTask.py
@@ -865,7 +865,7 @@ class DipoleFitAlgorithm:
         centroid = ((fitParams['xcenPos'] + fitParams['xcenNeg']) / 2.,
                     (fitParams['ycenPos'] + fitParams['ycenNeg']) / 2.)
         dx, dy = fitParams['xcenPos'] - fitParams['xcenNeg'], fitParams['ycenPos'] - fitParams['ycenNeg']
-        angle = np.arctan2(dy, dx) / np.pi * 180.   # convert to degrees (should keep as rad?)
+        angle = np.arctan2(dy, dx)
 
         # Exctract flux value, compute signalToNoise from flux/variance_within_footprint
         # Also extract the stderr of flux estimate.
@@ -1020,7 +1020,7 @@ class DipoleFitPlugin(measBase.SingleFramePlugin):
                                                                 measBase.UncertaintyEnum.SIGMA_ONLY)
 
         self.orientationKey = schema.addField(
-            schema.join(name, "orientation"), type=float, units="deg",
+            schema.join(name, "orientation"), type=float, units="rad",
             doc="Dipole orientation")
 
         self.separationKey = schema.addField(

--- a/python/lsst/ip/diffim/utils.py
+++ b/python/lsst/ip/diffim/utils.py
@@ -1326,14 +1326,14 @@ def angleMean(angles):
     Parameters
     ----------
     angles : `ndarray`
-        An array of angles, in degrees
+        An array of angles, in radians
 
     Returns
     -------
     `lsst.geom.Angle`
         The mean angle
     """
-    complexArray = [complex(np.cos(np.deg2rad(angle)), np.sin(np.deg2rad(angle))) for angle in angles]
+    complexArray = [complex(np.cos(angle), np.sin(angle)) for angle in angles]
     return (geom.Angle(np.angle(np.mean(complexArray))))
 
 

--- a/tests/test_detectAndMeasure.py
+++ b/tests/test_detectAndMeasure.py
@@ -348,7 +348,8 @@ class DetectAndMeasureTest(DetectAndMeasureTestBase, lsst.utils.tests.TestCase):
             if diaSource[dipoleFlag]:
                 self._check_diaSource(sources, diaSource, refIds=refIds, scale=0,
                                       rtol=0.05, atol=None, usePsfFlux=False)
-                self.assertFloatsAlmostEqual(diaSource["ip_diffim_DipoleFit_orientation"], -90., atol=2.)
+                self.assertFloatsAlmostEqual(diaSource["ip_diffim_DipoleFit_orientation"],
+                                             -np.pi / 2, atol=2.)
                 self.assertFloatsAlmostEqual(diaSource["ip_diffim_DipoleFit_separation"], offset, rtol=0.1)
             else:
                 raise ValueError("DiaSource with ID %s is not a dipole!", diaSource.getId())
@@ -733,7 +734,8 @@ class DetectAndMeasureScoreTest(DetectAndMeasureTestBase, lsst.utils.tests.TestC
             if diaSource[dipoleFlag]:
                 self._check_diaSource(sources, diaSource, refIds=refIds, scale=0,
                                       rtol=0.05, atol=None, usePsfFlux=False)
-                self.assertFloatsAlmostEqual(diaSource["ip_diffim_DipoleFit_orientation"], -90., atol=2.)
+                self.assertFloatsAlmostEqual(diaSource["ip_diffim_DipoleFit_orientation"],
+                                             -np.pi / 2, atol=2.)
                 self.assertFloatsAlmostEqual(diaSource["ip_diffim_DipoleFit_separation"], offset, rtol=0.1)
             else:
                 raise ValueError("DiaSource with ID %s is not a dipole!", diaSource.getId())

--- a/tests/test_utilsCalculations.py
+++ b/tests/test_utilsCalculations.py
@@ -39,7 +39,7 @@ class UtilsCalculationsTest(lsst.utils.tests.TestCase):
         nSrc = 100
         angleOffset = 30
         rng = np.random.RandomState(seed)
-        angles = (rng.rand(nSrc) - 0.5)*20 + angleOffset
+        angles = np.radians((rng.rand(nSrc) - 0.5)*20 + angleOffset)
         self.assertFloatsAlmostEqual(angleOffset, angleMean(angles).asDegrees(), rtol=0.01)
 
     def test_getPsfFwhm(self):


### PR DESCRIPTION
Changes unit of `orientation` for dipole to be degree instead of rad to match Science Pipeline standard.  Fixed calculation, specified unit, and tests.  ~6 lines changed.

Passes `ci_ap`:

https://rubin-ci.slac.stanford.edu/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/1555/pipeline
