### PR TITLE
DM-46061: Add Metrics to calibrate task metadata

### DIFF
--- a/python/lsst/ip/diffim/utils.py
+++ b/python/lsst/ip/diffim/utils.py
@@ -22,7 +22,13 @@
 """Support utilities for Measuring sources"""
 
 # Export DipoleTestImage to expose fake image generating funcs
-__all__ = ["DipoleTestImage", "evaluateMeanPsfFwhm", "getPsfFwhm", "getKernelCenterDisplacement"]
+__all__ = [
+    "DipoleTestImage",
+    "evaluateMaskFraction",
+    "evaluateMeanPsfFwhm",
+    "getPsfFwhm",
+    "getKernelCenterDisplacement",
+]
 
 import itertools
 import numpy as np


### PR DESCRIPTION
As requested in the review of `pipe_tasks/.../calibrate.py`, I have added the `evaluateMaskFraction` method to `__all__` in `utils.py`. Thanks for spotting that.