### PR TITLE
DM-45318: Add NO_DATA to detectAndMeasure's excludeMaskPlanes

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -197,7 +197,12 @@ class DetectAndMeasureConfig(pipeBase.PipelineTaskConfig,
         self.detection.thresholdValue = 5.0
         self.detection.reEstimateBackground = False
         self.detection.thresholdType = "pixel_stdev"
-        self.detection.excludeMaskPlanes = ["EDGE", "SAT", "BAD", "INTRP"]
+        self.detection.excludeMaskPlanes = ["EDGE",
+                                            "SAT",
+                                            "BAD",
+                                            "INTRP",
+                                            "NO_DATA",
+                                            ]
 
         self.measurement.plugins.names |= ["ext_trailedSources_Naive",
                                            "base_LocalPhotoCalib",


### PR DESCRIPTION
This PR adds NO_DATA to the list of masks to ignore when detecting sources in difference images alongside EDGE, SAT, BAD, and INTRP.