### PR TITLE
DM-47010: Drop obsoleted TODO comment.

### DIFF
--- a/python/lsst/ip/diffim/getTemplate.py
+++ b/python/lsst/ip/diffim/getTemplate.py
@@ -61,8 +61,6 @@ class GetTemplateConnections(pipeBase.PipelineTaskConnections,
         dimensions=("skymap", ),
         storageClass="SkyMap",
     )
-    # TODO DM-31292: Add option to use global external wcs from jointcal
-    # Needed for DRP HSC
     coaddExposures = pipeBase.connectionTypes.Input(
         doc="Input template to match and subtract from the exposure",
         dimensions=("tract", "patch", "skymap", "band"),


### PR DESCRIPTION
GetTemplateTask in DRP now reads 'pvi', which already has the final calibrations.