### PR TITLE
DM-48494: PsfMatch cleanups while exploring AL+DF kernel basis

### DIFF
--- a/include/lsst/ip/diffim/BuildSingleKernelVisitor.h
+++ b/include/lsst/ip/diffim/BuildSingleKernelVisitor.h
@@ -56,6 +56,12 @@ namespace detail {
         int getNProcessed()   {return _nProcessed;}
         void reset()          {_nRejected = 0; _nProcessed = 0;}
 
+        std::shared_ptr<lsst::daf::base::PropertySet> getPropertySet() { return _ps; }
+        bool getSkipBuilt() { return _skipBuilt; }
+        bool getUseRegularization() { return _useRegularization; }
+        bool getUseCoreStats() { return _useCoreStats; }
+        int getCoreRadius() { return _coreRadius; }
+
         void processCandidate(lsst::afw::math::SpatialCellCandidate *candidate);
 
     private:

--- a/python/lsst/ip/diffim/detail/buildSingleKernelVisitor.cc
+++ b/python/lsst/ip/diffim/detail/buildSingleKernelVisitor.cc
@@ -69,6 +69,13 @@ void declareBuildSingleKernelVisitor(lsst::cpputils::python::WrapperCollection &
         cls.def("getNProcessed", &BuildSingleKernelVisitor<PixelT>::getNProcessed);
         cls.def("reset", &BuildSingleKernelVisitor<PixelT>::reset);
         cls.def("processCandidate", &BuildSingleKernelVisitor<PixelT>::processCandidate, "candidate"_a);
+        cls.def_property_readonly("nRejected", &BuildSingleKernelVisitor<PixelT>::getNRejected);
+        cls.def_property_readonly("nProcessed", &BuildSingleKernelVisitor<PixelT>::getNProcessed);
+        cls.def_property_readonly("useRegularization", &BuildSingleKernelVisitor<PixelT>::getUseRegularization);
+        cls.def_property_readonly("skipBuilt", &BuildSingleKernelVisitor<PixelT>::getSkipBuilt);
+        cls.def_property_readonly("useCoreStats", &BuildSingleKernelVisitor<PixelT>::getUseCoreStats);
+        cls.def_property_readonly("coreRadius", &BuildSingleKernelVisitor<PixelT>::getCoreRadius);
+        cls.def_property_readonly("propertySet", &BuildSingleKernelVisitor<PixelT>::getPropertySet);
 
         mod.def("makeBuildSingleKernelVisitor",
                 (std::shared_ptr<BuildSingleKernelVisitor<PixelT>>(*)(afw::math::KernelList const &,

--- a/python/lsst/ip/diffim/makeKernel.py
+++ b/python/lsst/ip/diffim/makeKernel.py
@@ -94,8 +94,7 @@ class MakeKernelTask(PsfMatchTask):
     _DefaultName = "makeALKernel"
 
     def __init__(self, *args, **kwargs):
-        PsfMatchTask.__init__(self, *args, **kwargs)
-        self.kConfig = self.config.kernel.active
+        super().__init__(*args, **kwargs)
         # the background subtraction task uses a config from an unusual location,
         # so cannot easily be constructed with makeSubtask
         self.background = SubtractBackgroundTask(config=self.kConfig.afwBackgroundConfig, name="background",

--- a/python/lsst/ip/diffim/psfMatch.py
+++ b/python/lsst/ip/diffim/psfMatch.py
@@ -455,6 +455,12 @@ class PsfMatchTask(pipeBase.Task, abc.ABC):
     also performs background matching and returns the differential background model as an
     `lsst.afw.math.Kernel.SpatialFunction`.
 
+    The initialization sets the Psf-matching kernel configuration using the
+    value of self.config.kernel.active.  If the kernel is requested with
+    regularization to moderate the bias/variance tradeoff, currently only used
+    when a delta function kernel basis is provided, it creates a
+    regularization matrix stored as member variable self.hMat.
+
     **Invoking the Task**
 
     As a base class, this Task is not directly invoked.  However, ``run()`` methods that are
@@ -549,23 +555,6 @@ class PsfMatchTask(pipeBase.Task, abc.ABC):
     _DefaultName = "psfMatch"
 
     def __init__(self, *args, **kwargs):
-        """Create the psf-matching Task
-
-        Parameters
-        ----------
-        *args
-            Arguments to be passed to ``lsst.pipe.base.task.Task.__init__``
-        **kwargs
-            Keyword arguments to be passed to ``lsst.pipe.base.task.Task.__init__``
-
-        Notes
-        -----
-        The initialization sets the Psf-matching kernel configuration using the value of
-        self.config.kernel.active.  If the kernel is requested with regularization to moderate
-        the bias/variance tradeoff, currently only used when a delta function kernel basis
-        is provided, it creates a regularization matrix stored as member variable
-        self.hMat.
-        """
         pipeBase.Task.__init__(self, *args, **kwargs)
         self.kConfig = self.config.kernel.active
 


### PR DESCRIPTION
The combined kernel basis didn't work out, but I pushed my exploration of that onto tickets/DM-48494-nomerge, which I'll rebase onto main once this merges. These are just some cleanups I made along the way while exploring that.