### PR TITLE
DM-48827: Normalize footprint metrics by the size of the footprint

### DIFF
--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -520,9 +520,9 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
                 footprint = record.getFootprint()
                 heavy = lsst.afw.detection.makeHeavyFootprint(footprint, science.maskedImage)
                 heavy_diff = lsst.afw.detection.makeHeavyFootprint(footprint, difference.maskedImage)
-                science_footprints[i] = heavy.getImageArray().sum()
-                difference_footprints[i] = abs(heavy_diff.getImageArray()).sum()
-                ratio[i] = (difference_footprints[i] - sky) / science_footprints[i]
+                science_footprints[i] = abs(heavy.getImageArray()).mean()
+                difference_footprints[i] = abs(heavy_diff.getImageArray()).mean()
+                ratio[i] = abs((difference_footprints[i] - sky)/science_footprints[i])
             return science_footprints, difference_footprints, ratio
 
         sky = stars["sky_source"]

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -891,9 +891,11 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
         that the difference image limiting magnitude is calculated correctly,
         both with a "good" and "bad" seeing template.
         """
-        science, sources = makeTestImage(psfSize=1.8, doApplyCalibration=True)
-        template_good, _ = makeTestImage(psfSize=2.4, doApplyCalibration=True)
-        template_bad, _ = makeTestImage(psfSize=9.5, doApplyCalibration=True)
+        science, sources = makeTestImage(psfSize=2.8, noiseLevel=1)
+        template_good, _ = makeTestImage(psfSize=2.4, doApplyCalibration=True, noiseLevel=0.25,
+                                         templateBorderSize=20)
+        template_bad, _ = makeTestImage(psfSize=9.5, doApplyCalibration=True, noiseLevel=0.25,
+                                        templateBorderSize=20)
 
         # Add a few sky objects; sky footprints are needed for some metrics.
         config = measAlg.SkyObjectsTask.ConfigClass()
@@ -968,8 +970,8 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
         self.assertIn('templateLimitingMagnitude', subtractTask_good.metadata)
 
         # The mean ratio metric should be much worse on the "bad" subtraction.
-        self.assertLess(subtractTask_good.metadata['differenceFootprintRatioMean'], 0.2)
-        self.assertGreater(subtractTask_bad.metadata['differenceFootprintRatioMean'], 1.0)
+        self.assertLess(subtractTask_good.metadata['differenceFootprintRatioMean'], 0.02)
+        self.assertGreater(subtractTask_bad.metadata['differenceFootprintRatioMean'], 0.25)
 
 
 class AlardLuptonPreconvolveSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.TestCase):


### PR DESCRIPTION
Also set the "good" subtraction test to have better seeing in the template than the science image, so that template convolution is the right choice.