### PR TITLE
DM-48946: Defer quantum graph constraint on coadds for getTemplate.

### DIFF
--- a/python/lsst/ip/diffim/getTemplate.py
+++ b/python/lsst/ip/diffim/getTemplate.py
@@ -68,7 +68,8 @@ class GetTemplateConnections(pipeBase.PipelineTaskConnections,
         storageClass="ExposureF",
         name="{fakesType}{coaddName}Coadd{warpTypeSuffix}",
         multiple=True,
-        deferLoad=True
+        deferLoad=True,
+        deferGraphConstraint=True
     )
 
     template = pipeBase.connectionTypes.Output(


### PR DESCRIPTION
This greatly speeds up the quantum graph generation time for the AP pipeline, by restricting the initial constraints to be only based on raws and not the possible coadds used to make templates.