### PR TITLE
DM-49554: Do not attempt forced photometry in NO_DATA regions

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -257,7 +257,7 @@ class DetectAndMeasureConfig(pipeBase.PipelineTaskConfig,
         self.measurement.slots.psfShape = "ext_shapeHSM_HsmPsfMoments"
         self.measurement.slots.shape = "ext_shapeHSM_HsmSourceMoments"
         self.measurement.plugins["base_SdssCentroid"].maxDistToPeak = 5.0
-        self.forcedMeasurement.plugins = ["base_TransformedCentroid", "base_PsfFlux"]
+        self.forcedMeasurement.plugins = ["base_TransformedCentroid", "base_PsfFlux", "base_PixelFlags"]
         self.forcedMeasurement.copyColumns = {
             "id": "objectId", "parent": "parentObjectId", "coord_ra": "coord_ra", "coord_dec": "coord_dec"}
         self.forcedMeasurement.slots.centroid = "base_TransformedCentroid"


### PR DESCRIPTION
Add base_PixelFlags to forcedMeasurement

Forced photometry in DetectAndMeasure requires the base_PixelFlags plugin.