### PR TITLE
DM-50717: Run background subtraction in detectAndMeasure

### DIFF
--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -175,7 +175,7 @@ class AlardLuptonSubtractBaseConfig(lsst.pex.config.Config):
     doSubtractBackground = lsst.pex.config.Field(
         doc="Subtract the background fit when solving the kernel?",
         dtype=bool,
-        default=True,
+        default=False,
     )
     doApplyExternalCalibrations = lsst.pex.config.Field(
         doc=(

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -528,6 +528,11 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
     def test_background_subtraction(self):
         """Check that we can recover the background,
         and that it is subtracted correctly in the difference image.
+
+        NOTE: Background subtraction is now turned off by default in
+        subtractImages. It is now run in detectAndMeasure instead, but since the
+        code to run background subtraction is not being removed this test should
+        stay to make sure it continues functioning as intended.
         """
         noiseLevel = 1.
         xSize = 512
@@ -971,7 +976,7 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
 
         # The mean ratio metric should be much worse on the "bad" subtraction.
         self.assertLess(subtractTask_good.metadata['differenceFootprintRatioMean'], 0.02)
-        self.assertGreater(subtractTask_bad.metadata['differenceFootprintRatioMean'], 0.17)
+        self.assertGreater(subtractTask_bad.metadata['differenceFootprintRatioMean'], 0.12)
 
 
 class AlardLuptonPreconvolveSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.TestCase):


### PR DESCRIPTION
This moves background subtraction out of `subtractImages` where it was previously done as part of the psf matching kernel fit, and into a subtask in `detectAndMeasure`.