### PR TITLE
DM-51329: Use a slightly larger binsize for background subtraction

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -252,7 +252,7 @@ class DetectAndMeasureConfig(pipeBase.PipelineTaskConfig,
         self.subtractInitialBackground.doFilterSuperPixels = True
         # Use a larger binsize for the final background subtraction, to reduce
         #  over-subtraction of bright objects.
-        self.subtractFinalBackground.binSize = 32
+        self.subtractFinalBackground.binSize = 40
         self.subtractFinalBackground.useApprox = False
         self.subtractFinalBackground.statisticsProperty = "MEDIAN"
         self.subtractFinalBackground.doFilterSuperPixels = True


### PR DESCRIPTION
The changes on DM-50980 fixed a minor bug that had resulted in using larger bins for background subtraction.