### PR TITLE
DM-51401: Ensure subTest arguments are strings.

### DIFF
--- a/tests/test_dipoleFitter.py
+++ b/tests/test_dipoleFitter.py
@@ -187,29 +187,29 @@ class DipoleFitTest(lsst.utils.tests.TestCase):
             # self.assertFloatsAlmostEqual(record['ip_diffim_DipoleFit_instFluxErr'],
             #                              ???, rtol=rtol)
             # emperical uncertainty values: not clear how to compute proper expected values.
-            with self.subTest(i=i, type="pos_xErr"):
+            with self.subTest(i=repr(i), type="pos_xErr"):
                 self.assertFloatsAlmostEqual(record['ip_diffim_DipoleFit_pos_xErr'],
                                              .53*record["base_SdssCentroid_xErr"],
                                              rtol=0.1 if not noPreImages else 0.5)
-            with self.subTest(i=i, type="pos_yErr"):
+            with self.subTest(i=repr(i), type="pos_yErr"):
                 self.assertFloatsAlmostEqual(record['ip_diffim_DipoleFit_pos_yErr'],
                                              .53*record["base_SdssCentroid_yErr"],
                                              rtol=0.1 if not noPreImages else 0.5)
-            with self.subTest(i=i, type="neg_xErr"):
+            with self.subTest(i=repr(i), type="neg_xErr"):
                 self.assertFloatsAlmostEqual(record['ip_diffim_DipoleFit_neg_xErr'],
                                              .53*record["base_SdssCentroid_xErr"],
                                              rtol=0.1 if not noPreImages else 0.5)
-            with self.subTest(i=i, type="neg_yErr"):
+            with self.subTest(i=repr(i), type="neg_yErr"):
                 self.assertFloatsAlmostEqual(record['ip_diffim_DipoleFit_neg_yErr'],
                                              .53*record["base_SdssCentroid_yErr"],
                                              rtol=0.1 if not noPreImages else 0.5)
             # NOTE: these are smaller than the positive/negative uncertainties,
             # because the of those covariance is negative!
-            with self.subTest(i=i, type="xErr"):
+            with self.subTest(i=repr(i), type="xErr"):
                 self.assertFloatsAlmostEqual(record['ip_diffim_DipoleFit_xErr'],
                                              .34*record["base_SdssCentroid_xErr"],
                                              rtol=0.06 if not noPreImages else 0.5)
-            with self.subTest(i=i, type="yErr"):
+            with self.subTest(i=repr(i), type="yErr"):
                 self.assertFloatsAlmostEqual(record['ip_diffim_DipoleFit_yErr'],
                                              .35*record["base_SdssCentroid_yErr"],
                                              rtol=0.06 if not noPreImages else 0.5)


### PR DESCRIPTION
pytest-xdist chokes on the error messages otherwise, causing the test to fail.