### PR TITLE
DM-51635: LSSTCam DRP error in subtractImages with undefined maglim

### DIFF
--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -668,10 +668,14 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
         """
         if exposure.photoCalib is None:
             return np.nan
+        # Set maglim to nan upfront in case on an unexpected RuntimeError
+        maglim = np.nan
         try:
             psf = exposure.getPsf()
             psf_shape = psf.computeShape(psf.getAveragePosition())
-        except (lsst.pex.exceptions.InvalidParameterError, afwDetection.InvalidPsfError):
+        except (lsst.pex.exceptions.InvalidParameterError,
+                afwDetection.InvalidPsfError,
+                lsst.pex.exceptions.RangeError):
             if fallbackPsfSize is not None:
                 self.log.info("Unable to evaluate PSF, using fallback FWHM %f", fallbackPsfSize)
                 psf_area = np.pi*(fallbackPsfSize/2)**2


### PR DESCRIPTION
This PR fixes the bug as reported, but does not fix the underlying issue of why the PSF cannot be evaluated at the average position for this image. I looked at the visit (detector=150, visit=2025060400401) that caused the failure on RubinTV and didn't see anything obviously wrong or unusual.