### PR TITLE
Revert DM-51228 (perform forced photometry on template)

### DIFF
--- a/tests/test_detectAndMeasure.py
+++ b/tests/test_detectAndMeasure.py
@@ -211,8 +211,7 @@ class DetectAndMeasureTest(DetectAndMeasureTestBase, lsst.utils.tests.TestCase):
     def test_measurements_finite(self):
         """Measured fluxes and centroids should always be finite.
         """
-        columnNames = ["coord_ra", "coord_dec", "ip_diffim_forced_PsfFlux_instFlux",
-                       "ip_diffim_forced_template_PsfFlux_instFlux"]
+        columnNames = ["coord_ra", "coord_dec", "ip_diffim_forced_PsfFlux_instFlux"]
 
         # Set up the simulated images
         noiseLevel = 1.
@@ -756,8 +755,7 @@ class DetectAndMeasureScoreTest(DetectAndMeasureTestBase, lsst.utils.tests.TestC
     def test_measurements_finite(self):
         """Measured fluxes and centroids should always be finite.
         """
-        columnNames = ["coord_ra", "coord_dec", "ip_diffim_forced_PsfFlux_instFlux",
-                       "ip_diffim_forced_template_PsfFlux_instFlux"]
+        columnNames = ["coord_ra", "coord_dec", "ip_diffim_forced_PsfFlux_instFlux"]
 
         # Set up the simulated images
         noiseLevel = 1.


### PR DESCRIPTION
This reverts commit 6c75a56628a410d164480ec06304ad4a9c83b953, reversing changes made to 5e1b9f9e8cdc06e71932d1597421bd24ea25bd57.