### PR TITLE
DM-52106: Image differencing cleanups

### DIFF
--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -374,22 +374,6 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
         """
         self._prepareInputs(template, science, visitSummary=visitSummary)
 
-        #  Calculate estimated image depths, i.e., limiting magnitudes
-        maglim_science = self._calculateMagLim(science, fallbackPsfSize=self.sciencePsfSize)
-        if np.isnan(maglim_science):
-            self.log.warning("Limiting magnitude of the science image is NaN!")
-        fluxlim_science = (maglim_science*u.ABmag).to_value(u.nJy)
-        maglim_template = self._calculateMagLim(template, fallbackPsfSize=self.templatePsfSize)
-        if np.isnan(maglim_template):
-            self.log.info("Cannot evaluate template limiting mag; adopting science limiting mag for diffim")
-            maglim_diffim = maglim_science
-        else:
-            fluxlim_template = (maglim_template*u.ABmag).to_value(u.nJy)
-            maglim_diffim = (np.sqrt(fluxlim_science**2 + fluxlim_template**2)*u.nJy).to(u.ABmag).value
-        self.metadata["scienceLimitingMagnitude"] = maglim_science
-        self.metadata["templateLimitingMagnitude"] = maglim_template
-        self.metadata["diffimLimitingMagnitude"] = maglim_diffim
-
         if self.config.mode == "auto":
             convolveTemplate = _shapeTest(template,
                                           science,
@@ -898,6 +882,22 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
         self.log.info("Template PSF FWHM: %f pixels", self.templatePsfSize)
         self.metadata["sciencePsfSize"] = self.sciencePsfSize
         self.metadata["templatePsfSize"] = self.templatePsfSize
+
+        #  Calculate estimated image depths, i.e., limiting magnitudes
+        maglim_science = self._calculateMagLim(science, fallbackPsfSize=self.sciencePsfSize)
+        if np.isnan(maglim_science):
+            self.log.warning("Limiting magnitude of the science image is NaN!")
+        fluxlim_science = (maglim_science*u.ABmag).to_value(u.nJy)
+        maglim_template = self._calculateMagLim(template, fallbackPsfSize=self.templatePsfSize)
+        if np.isnan(maglim_template):
+            self.log.info("Cannot evaluate template limiting mag; adopting science limiting mag for diffim")
+            maglim_diffim = maglim_science
+        else:
+            fluxlim_template = (maglim_template*u.ABmag).to_value(u.nJy)
+            maglim_diffim = (np.sqrt(fluxlim_science**2 + fluxlim_template**2)*u.nJy).to(u.ABmag).value
+        self.metadata["scienceLimitingMagnitude"] = maglim_science
+        self.metadata["templateLimitingMagnitude"] = maglim_template
+        self.metadata["diffimLimitingMagnitude"] = maglim_diffim
 
     def updateMasks(self, template, science):
         """Update the science and template mask planes before differencing.

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -193,13 +193,15 @@ class AlardLuptonSubtractBaseConfig(lsst.pex.config.Config):
         dtype=float,
         default=10,
         doc="Minimum signal to noise ratio of detected sources "
-        "to use for calculating the PSF matching kernel."
+        "to use for calculating the PSF matching kernel.",
+        deprecated="No longer used. Will be removed after v30"
     )
     detectionThresholdMax = lsst.pex.config.Field(
         dtype=float,
         default=500,
         doc="Maximum signal to noise ratio of detected sources "
-        "to use for calculating the PSF matching kernel."
+        "to use for calculating the PSF matching kernel.",
+        deprecated="No longer used. Will be removed after v30"
     )
     maxKernelSources = lsst.pex.config.Field(
         dtype=int,
@@ -215,7 +217,8 @@ class AlardLuptonSubtractBaseConfig(lsst.pex.config.Config):
     excludeMaskPlanes = lsst.pex.config.ListField(
         dtype=str,
         default=("NO_DATA", "BAD", "SAT", "EDGE", "FAKE"),
-        doc="Mask planes to exclude when selecting sources for PSF matching."
+        doc="Mask planes to exclude when selecting sources for PSF matching.",
+        deprecated="No longer used. Will be removed after v30"
     )
     badMaskPlanes = lsst.pex.config.ListField(
         dtype=str,

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -389,6 +389,9 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
                 PSF-matching kernel
             ``psfMatchingKernel`` : `lsst.afw.math.Kernel`
                 Kernel used to PSF-match the convolved image.
+            ``kernelSources` : `lsst.afw.table.SourceCatalog`
+                Sources from the input catalog that were used to construct the
+                PSF-matching kernel.
 
         Raises
         ------

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -803,10 +803,6 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
         """
 
         selected = self.sourceSelector.selectSources(sources).selected
-        nInitialSelected = np.count_nonzero(selected)
-        nSelected = np.count_nonzero(selected)
-        self.log.info("Rejecting %i candidate sources: an excluded template mask plane is set.",
-                      nInitialSelected - nSelected)
         selectSources = sources[selected].copy(deep=True)
         # Trim selectSources if they exceed ``maxKernelSources``.
         # Keep the highest signal-to-noise sources of those selected.

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -173,7 +173,8 @@ class AlardLuptonSubtractBaseConfig(lsst.pex.config.Config):
         doc="Subtask to rescale the variance of the template to the statistically expected level."
     )
     doSubtractBackground = lsst.pex.config.Field(
-        doc="Subtract the background fit when solving the kernel?",
+        doc="Subtract the background fit when solving the kernel? "
+        "It is generally better to instead subtract the background in detectAndMeasure.",
         dtype=bool,
         default=False,
     )

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -451,11 +451,13 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
         template, _ = makeTestImage(psfSize=2.0, nSrc=nSourcesSimulated,
                                     xSize=xSize, ySize=ySize, doApplyCalibration=True)
 
-        def _run_and_check_sources(sourcesIn, maxKernelSources=1000, minKernelSources=3):
+        def _run_and_check_sources(sourcesIn, maxKernelSources=1000, minKernelSources=3,
+                                   restrictKernelEdgeSources=False):
             sources = sourcesIn.copy(deep=True)
 
             task = self._setup_subtraction(maxKernelSources=maxKernelSources,
                                            minKernelSources=minKernelSources,
+                                           restrictKernelEdgeSources=restrictKernelEdgeSources,
                                            )
             # Verify that source flags are not set in the input catalog
             # Note that this will use the last flag in the list for the rest of
@@ -465,6 +467,12 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
             nSources = len(sources)
             # Flag a third of the sources
             sources[0:: 3][badSourceFlag] = True
+            if restrictKernelEdgeSources:
+                rejectRadius = 2*task.config.makeKernel.kernel.active.kernelSize
+                bbox = science.getBBox()
+                bbox.grow(-rejectRadius)
+                edgeSources = ~bbox.contains(sources.getX(), sources.getY())
+                sources[edgeSources][badSourceFlag] = True
             nBadSources = np.sum(sources[badSourceFlag])
             if maxKernelSources > 0:
                 nGoodSources = np.minimum(nSources - nBadSources, maxKernelSources)
@@ -474,7 +482,7 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
             signalToNoise = sources.getPsfInstFlux()/sources.getPsfInstFluxErr()
             signalToNoise = signalToNoise[~sources[badSourceFlag]]
             signalToNoise.sort()
-            selectSources = task._sourceSelector(sources, science.mask)
+            selectSources = task._sourceSelector(sources, science.getBBox())
             self.assertEqual(nGoodSources, len(selectSources))
             signalToNoiseOut = selectSources.getPsfInstFlux()/selectSources.getPsfInstFluxErr()
             signalToNoiseOut.sort()
@@ -482,6 +490,8 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
 
         _run_and_check_sources(sources)
         _run_and_check_sources(sources, maxKernelSources=len(sources)//3)
+        _run_and_check_sources(sources, restrictKernelEdgeSources=True)
+        _run_and_check_sources(sources, maxKernelSources=len(sources)//3, restrictKernelEdgeSources=True)
         _run_and_check_sources(sources, maxKernelSources=-1)
         with self.assertRaises(RuntimeError):
             _run_and_check_sources(sources, minKernelSources=1000)
@@ -671,6 +681,7 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
             task = self._setup_subtraction(mode="convolveScience",
                                            doDecorrelation=doDecorrelation,
                                            doScaleVariance=doScaleVariance,
+                                           restrictKernelEdgeSources=False,
                                            )
             output = task.run(template.clone(), science.clone(), sources)
             if doScaleVariance:

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -27,7 +27,7 @@ import lsst.afw.math as afwMath
 import lsst.afw.table as afwTable
 import lsst.geom
 import lsst.meas.algorithms as measAlg
-from lsst.ip.diffim import subtractImages
+from lsst.ip.diffim import subtractImages, InsufficientKernelSourcesError
 from lsst.pex.config import FieldValidationError
 from lsst.pipe.base import NoWorkFound
 import lsst.utils.tests
@@ -436,8 +436,7 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
         template, _ = makeTestImage(psfSize=2.0, nSrc=10, xSize=xSize, ySize=ySize, doApplyCalibration=True)
         task = self._setup_subtraction()
         sources = sources[0:1]
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Cannot compute PSF matching kernel: too few sources selected."):
+        with self.assertRaises(InsufficientKernelSourcesError):
             task.run(template, science, sources)
 
     def test_kernel_source_selector(self):
@@ -1159,8 +1158,7 @@ class AlardLuptonPreconvolveSubtractTest(AlardLuptonSubtractTestBase, lsst.utils
         template, _ = makeTestImage(psfSize=2.0, nSrc=10, xSize=xSize, ySize=ySize, doApplyCalibration=True)
         task = self._setup_subtraction()
         sources = sources[0:1]
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Cannot compute PSF matching kernel: too few sources selected."):
+        with self.assertRaises(InsufficientKernelSourcesError):
             task.run(template, science, sources)
 
     def test_background_subtraction(self):


### PR DESCRIPTION
Moving a number of cleanups from DM-44936, which is not expected to merge soon. 