### PR TITLE
DM-52420: Add flag for diaSources in high variance regions

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -416,9 +416,9 @@ class DetectAndMeasureConfig(pipeBase.PipelineTaskConfig,
 
         # Keep track of which footprints contain streaks
         self.measurement.plugins["base_PixelFlags"].masksFpAnywhere = [
-            "STREAK", "INJECTED", "INJECTED_TEMPLATE"]
+            "STREAK", "INJECTED", "INJECTED_TEMPLATE", "HIGH_VARIANCE"]
         self.measurement.plugins["base_PixelFlags"].masksFpCenter = [
-            "STREAK", "INJECTED", "INJECTED_TEMPLATE"]
+            "STREAK", "INJECTED", "INJECTED_TEMPLATE", "HIGH_VARIANCE"]
         self.skySources.avoidMask = ["DETECTED", "DETECTED_NEGATIVE", "BAD", "NO_DATA", "EDGE"]
 
     def validate(self):

--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -808,7 +808,10 @@ class DetectAndMeasureTask(lsst.pipe.base.PipelineTask):
             # This option allows returning sky sources,
             # even if there are no diaSources
             measurementResults.diaSources = diaSources
-
+        self.log.info("Measured %d diaSources and %d sky sources",
+                      np.count_nonzero(~diaSources["sky_source"]),
+                      np.count_nonzero(diaSources["sky_source"])
+                      )
         return measurementResults
 
     def _deblend(self, difference, positiveFootprints, negativeFootprints):

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -921,6 +921,11 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
             Bounding box of the science image.
         mask : `lsst.afw.image.Mask`
             The mask plane of the template to use to reject kernel candidates.
+        fallback : `bool`, optional
+            Switch indicating the source selector is being called after
+            running the fallback source detection subtask, which does not run a
+            full set of measurement plugins and can't use the same settings for
+            the source selector.
 
         Returns
         -------
@@ -930,6 +935,9 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
 
         Raises
         ------
+        InsufficientKernelSourcesError
+            An AlgorithmError that is raised if there are not enough PSF
+            candidates to construct the PSF matching kernel.
         RuntimeError
             If there are too few sources to compute the PSF matching kernel
             remaining after source selection.

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -268,8 +268,8 @@ class AlardLuptonSubtractBaseConfig(lsst.pex.config.Config):
     )
     excludeMaskPlanes = lsst.pex.config.ListField(
         dtype=str,
-        default=("NO_DATA", "BAD", "SAT", "EDGE", "FAKE"),
-        doc="Mask planes to exclude when selecting sources for PSF matching.",
+        default=("NO_DATA", "BAD", "SAT", "EDGE", "FAKE", "HIGH_VARIANCE"),
+        doc="Template mask planes to exclude when selecting sources for PSF matching.",
     )
     badMaskPlanes = lsst.pex.config.ListField(
         dtype=str,
@@ -278,7 +278,7 @@ class AlardLuptonSubtractBaseConfig(lsst.pex.config.Config):
     )
     preserveTemplateMask = lsst.pex.config.ListField(
         dtype=str,
-        default=("NO_DATA", "BAD",),
+        default=("NO_DATA", "BAD", "HIGH_VARIANCE"),
         doc="Mask planes from the template to propagate to the image difference."
     )
     renameTemplateMask = lsst.pex.config.ListField(

--- a/python/lsst/ip/diffim/subtractImages.py
+++ b/python/lsst/ip/diffim/subtractImages.py
@@ -26,7 +26,7 @@ import lsst.afw.detection as afwDetection
 import lsst.afw.image
 import lsst.afw.math
 import lsst.geom
-from lsst.ip.diffim.utils import evaluateMeanPsfFwhm, getPsfFwhm, computeDifferenceImageMetrics
+from lsst.ip.diffim.utils import evaluateMeanPsfFwhm, getPsfFwhm, computeDifferenceImageMetrics, checkMask
 from lsst.meas.algorithms import ScaleVarianceTask, ScienceSourceSelectorTask
 import lsst.pex.config
 import lsst.pipe.base
@@ -270,7 +270,6 @@ class AlardLuptonSubtractBaseConfig(lsst.pex.config.Config):
         dtype=str,
         default=("NO_DATA", "BAD", "SAT", "EDGE", "FAKE"),
         doc="Mask planes to exclude when selecting sources for PSF matching.",
-        deprecated="No longer used. Will be removed after v30"
     )
     badMaskPlanes = lsst.pex.config.ListField(
         dtype=str,
@@ -443,7 +442,7 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
 
         convolveTemplate = self.chooseConvolutionMethod(template, science)
 
-        selectSources = self._sourceSelector(sources, science.getBBox())
+        selectSources = self._sourceSelector(sources, science.getBBox(), template.mask)
 
         kernelResult = self.runMakeKernel(template, science, selectSources,
                                           convolveTemplate=convolveTemplate)
@@ -627,7 +626,7 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
                                                       scienceFwhmPix=self.sciencePsfSize)
 
         # return sources
-        return self._sourceSelector(sources, science.getBBox(), fallback=True)
+        return self._sourceSelector(sources, science.getBBox(), template.mask, fallback=True)
 
     def runConvolveTemplate(self, template, science, psfMatchingKernel, backgroundModel=None):
         """Convolve the template image with a PSF-matching kernel and subtract
@@ -908,7 +907,7 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
         else:
             return convolvedExposure[bbox]
 
-    def _sourceSelector(self, sources, bbox, fallback=False):
+    def _sourceSelector(self, sources, bbox, mask, fallback=False):
         """Select sources from a catalog that meet the selection criteria.
         The selection criteria include any configured parameters of the
         `sourceSelector` subtask, as well as distance from the edge if
@@ -920,6 +919,8 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
             Input source catalog to select sources from.
         bbox : `lsst.geom.Box2I`
             Bounding box of the science image.
+        mask : `lsst.afw.image.Mask`
+            The mask plane of the template to use to reject kernel candidates.
 
         Returns
         -------
@@ -945,6 +946,9 @@ class AlardLuptonSubtractTask(lsst.pipe.base.PipelineTask):
                           np.count_nonzero(~bboxSelected), rejectRadius)
             selected &= bboxSelected
         selectSources = sources[selected].copy(deep=True)
+        # Optionally remove sources that land on masked pixels
+        maskSelected = checkMask(mask, selectSources, self.config.excludeMaskPlanes, checkAdjacent=True)
+        selectSources = selectSources[maskSelected].copy(deep=True)
         # Trim selectSources if they exceed ``maxKernelSources``.
         # Keep the highest signal-to-noise sources of those selected.
         if (len(selectSources) > self.config.maxKernelSources) & (self.config.maxKernelSources > 0):
@@ -1211,7 +1215,7 @@ class AlardLuptonPreconvolveSubtractTask(AlardLuptonSubtractTask):
                                                 interpolateBadMaskPlanes=True)
         self.metadata["convolvedExposure"] = "Preconvolution"
         try:
-            selectSources = self._sourceSelector(sources, science.getBBox())
+            selectSources = self._sourceSelector(sources, science.getBBox(), template.mask)
             subtractResults = self.runPreconvolve(template, science, matchedScience,
                                                   selectSources, scienceKernel)
 

--- a/python/lsst/ip/diffim/utils.py
+++ b/python/lsst/ip/diffim/utils.py
@@ -23,7 +23,7 @@
 
 
 __all__ = ["evaluateMeanPsfFwhm", "getPsfFwhm", "getKernelCenterDisplacement",
-           "computeDifferenceImageMetrics",
+           "computeDifferenceImageMetrics", "checkMask"
            ]
 
 import itertools
@@ -454,3 +454,44 @@ def populate_sattle_visit_cache(visit_info, historical=False):
               "historical": historical})
 
     r.raise_for_status()
+
+
+def checkMask(mask, sources, excludeMaskPlanes, checkAdjacent=True):
+    """Exclude sources that are located on or adjacent to masked pixels.
+
+    Parameters
+    ----------
+    mask : `lsst.afw.image.Mask`
+        The image mask plane to use to reject sources
+        based on the location of their centroid on the ccd.
+    sources : `lsst.afw.table.SourceCatalog`
+        The source catalog to evaluate.
+    excludeMaskPlanes : `list` of `str`
+        List of the names of the mask planes to exclude.
+
+    Returns
+    -------
+    flags : `numpy.ndarray` of `bool`
+        Array indicating whether each source in the catalog should be
+        kept (True) or rejected (False) based on the value of the
+        mask plane at its location.
+    """
+    setExcludeMaskPlanes = [
+        maskPlane for maskPlane in excludeMaskPlanes if maskPlane in mask.getMaskPlaneDict()
+    ]
+
+    excludePixelMask = mask.getPlaneBitMask(setExcludeMaskPlanes)
+
+    xv = (np.rint(sources.getX() - mask.getX0())).astype(int)
+    yv = (np.rint(sources.getY() - mask.getY0())).astype(int)
+
+    flags = np.ones(len(sources), dtype=bool)
+    if checkAdjacent:
+        pixRange = (0, -1, 1)
+    else:
+        pixRange = (0,)
+    for j in pixRange:
+        for i in pixRange:
+            mv = mask.array[yv + j, xv + i]
+            flags *= np.bitwise_and(mv, excludePixelMask) == 0
+    return flags

--- a/tests/test_subtractTask.py
+++ b/tests/test_subtractTask.py
@@ -117,9 +117,9 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
         border = 20
         xSize = 400
         ySize = 400
-        science, sources = makeTestImage(psfSize=3.0, noiseLevel=noiseLevel, noiseSeed=6, nSrc=50,
+        science, sources = makeTestImage(psfSize=3.0, noiseLevel=noiseLevel, noiseSeed=6, nSrc=100,
                                          xSize=xSize, ySize=ySize)
-        template, _ = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=7, nSrc=50,
+        template, _ = makeTestImage(psfSize=2.0, noiseLevel=noiseLevel, noiseSeed=7, nSrc=100,
                                     templateBorderSize=border, doApplyCalibration=True,
                                     xSize=xSize, ySize=ySize)
 
@@ -485,7 +485,7 @@ class AlardLuptonSubtractTest(AlardLuptonSubtractTestBase, lsst.utils.tests.Test
             signalToNoise = sources.getPsfInstFlux()/sources.getPsfInstFluxErr()
             signalToNoise = signalToNoise[~sources[badSourceFlag]]
             signalToNoise.sort()
-            selectSources = task._sourceSelector(sources, science.getBBox())
+            selectSources = task._sourceSelector(sources, science.getBBox(), template.mask)
             self.assertEqual(nGoodSources, len(selectSources))
             signalToNoiseOut = selectSources.getPsfInstFlux()/selectSources.getPsfInstFluxErr()
             signalToNoiseOut.sort()


### PR DESCRIPTION
Add a new `HIGH_VARIANCE` mask plane.
Add the `checkMask` utility back in (was removed earlier this year) to allow rejecting PSF-match candidates based on the template mask plane.
Add flags to the diaSource catalog to indicate whether the source is in a high variance region.