### PR TITLE
DM-55814: Add timing metric for filterSatellites function

### DIFF
--- a/python/lsst/ip/diffim/detectAndMeasure.py
+++ b/python/lsst/ip/diffim/detectAndMeasure.py
@@ -1369,6 +1369,7 @@ class DetectAndMeasureTask(lsst.pipe.base.PipelineTask):
 
         return sattle_output.json()['allow_list']
 
+    @timeMethod
     def filterSatellites(self, diaSources, science):
         """Remove diaSources overlapping predicted satellite positions.
 


### PR DESCRIPTION
Add a timing metric call to the filterSatellites function so we can see how long sattle takes independent of detectAndMeasure. 